### PR TITLE
use uint8 instead of deprecated byte

### DIFF
--- a/rcl_interfaces/msg/ParameterValue.msg
+++ b/rcl_interfaces/msg/ParameterValue.msg
@@ -10,4 +10,4 @@ bool bool_value
 int64 integer_value
 float64 double_value
 string string_value
-byte[] bytes_value
+uint8[] bytes_value


### PR DESCRIPTION
don't use deprecated byte but uint8

connects to https://github.com/ros2/rosidl/issues/190