### PR TITLE
Provide defaults for ParameterValue fields

### DIFF
--- a/rcl_interfaces/msg/ParameterValue.msg
+++ b/rcl_interfaces/msg/ParameterValue.msg
@@ -6,7 +6,7 @@
 uint8 type
 
 # "Variant" style storage of the parameter value.
-bool bool_value False
+bool bool_value false
 int64 integer_value 0
 float64 double_value 0.0
 string string_value ""

--- a/rcl_interfaces/msg/ParameterValue.msg
+++ b/rcl_interfaces/msg/ParameterValue.msg
@@ -6,8 +6,8 @@
 uint8 type
 
 # "Variant" style storage of the parameter value.
-bool bool_value
-int64 integer_value
-float64 double_value
-string string_value
-byte[] bytes_value
+bool bool_value False
+int64 integer_value 0
+float64 double_value 0.0
+string string_value ""
+byte[] bytes_value []

--- a/rcl_interfaces/msg/ParameterValue.msg
+++ b/rcl_interfaces/msg/ParameterValue.msg
@@ -10,4 +10,4 @@ bool bool_value False
 int64 integer_value 0
 float64 double_value 0.0
 string string_value ""
-byte[] bytes_value []
+byte[] bytes_value


### PR DESCRIPTION
Even though only one field for a particular parameter is intended to be used at a time, to prevent serialisation of uninitialised fields we put defaults for all of them.

This is an alternative to https://github.com/ros2/rclcpp/pull/358, both designed to fix the valgrind error referenced in that PR.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3026)](http://ci.ros2.org/job/ci_linux/3026/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=437)](http://ci.ros2.org/job/ci_linux-aarch64/437/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2434)](http://ci.ros2.org/job/ci_osx/2434/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3108)](http://ci.ros2.org/job/ci_windows/3108/)