### PR TITLE
Make rcl_interfaces and lifecycle_msgs depend on rosidl_runtime_cpp.

### DIFF
--- a/lifecycle_msgs/CMakeLists.txt
+++ b/lifecycle_msgs/CMakeLists.txt
@@ -14,6 +14,9 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+
+include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
 
 set(msg_files
   "msg/State.msg"

--- a/lifecycle_msgs/CMakeLists.txt
+++ b/lifecycle_msgs/CMakeLists.txt
@@ -39,6 +39,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
 
 ament_package()

--- a/lifecycle_msgs/package.xml
+++ b/lifecycle_msgs/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/lifecycle_msgs/package.xml
+++ b/lifecycle_msgs/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>rosidl_runtime_cpp</build_depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rosidl_runtime_cpp</exec_depend>
 

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -41,4 +41,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(rosidl_default_runtime rosidl_runtime_cpp)
+
 ament_package()

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+include_directories(${rosidl_runtime_cpp_INCLUDE_DIRS})
 
 # ament_export_dependencies(rcl_interfaces)
 

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -13,6 +13,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>rosidl_runtime_cpp</build_depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rosidl_runtime_cpp</exec_depend>
 

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_runtime_cpp</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

relates to ros2/ros2#393

See CI in ros2/rosidl#231