### PR TITLE
Version numbers in repos must be consisistent across packages.

### DIFF
--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>test_msgs</name>
-  <version>0.0.0</version>
+  <version>0.0.2</version>
   <description>A package containing message definitions and fixtures used exclusively for testing purposes.</description>
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Bumps to version 0.0.2 (it'll move to 0.0.3 with everything else at tag and freeze.) to allow bloom to run.