### PR TITLE
Revert "Provide defaults for ParameterValue fields (#18)"

### DIFF
--- a/rcl_interfaces/msg/ParameterValue.msg
+++ b/rcl_interfaces/msg/ParameterValue.msg
@@ -6,8 +6,8 @@
 uint8 type
 
 # "Variant" style storage of the parameter value.
-bool bool_value false
-int64 integer_value 0
-float64 double_value 0.0
-string string_value ""
+bool bool_value
+int64 integer_value
+float64 double_value
+string string_value
 byte[] bytes_value


### PR DESCRIPTION
This reverts commit d25c83b657db452c6abf51aacf5a6793c3941473.

Fixes #19 
connects to ros2/ros2#396
@clalancette FYI

Same valgrind test as in https://github.com/ros2/rclcpp/pull/358
```
==4814== HEAP SUMMARY:
==4814==     in use at exit: 96,348 bytes in 48 blocks
==4814==   total heap usage: 5,768 allocs, 5,720 frees, 7,413,891 bytes allocated
==4814== 
==4814== Searching for pointers to 48 not-freed blocks
==4814== Checked 634,008 bytes
==4814== 
==4814== LEAK SUMMARY:
==4814==    definitely lost: 0 bytes in 0 blocks
==4814==    indirectly lost: 0 bytes in 0 blocks
==4814==      possibly lost: 0 bytes in 0 blocks
==4814==    still reachable: 96,348 bytes in 48 blocks
==4814==         suppressed: 0 bytes in 0 blocks
==4814== Rerun with --leak-check=full to see details of leaked memory
==4814== 
==4814== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==4814== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
