### PR TITLE
Add RclHeader message

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -49,4 +49,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(rosidl_default_runtime)
+
 ament_package()

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -26,6 +26,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Parameter.msg"
   "msg/ParameterType.msg"
   "msg/ParameterValue.msg"
+  "msg/RclHeader.msg"
   "msg/SetParametersResult.msg"
   "srv/DescribeParameters.srv"
   "srv/GetParameters.srv"
@@ -33,6 +34,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListParameters.srv"
   "srv/SetParametersAtomically.srv"
   "srv/SetParameters.srv"
+  DEPENDENCIES builtin_interfaces
+  ADD_LINTER_TESTS
 )
 
 # this must happen before the invocation of ament_package()

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -15,9 +15,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-# ament_export_dependencies(rcl_interfaces)
-
-rosidl_generate_interfaces(${PROJECT_NAME}
+set(msg_files
   "msg/IntraProcessMessage.msg"
   "msg/ListParametersResult.msg"
   "msg/ParameterDescriptor.msg"
@@ -28,12 +26,19 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ParameterValue.msg"
   "msg/RclHeader.msg"
   "msg/SetParametersResult.msg"
+)
+
+set(srv_files
   "srv/DescribeParameters.srv"
   "srv/GetParameters.srv"
   "srv/GetParameterTypes.srv"
   "srv/ListParameters.srv"
   "srv/SetParametersAtomically.srv"
   "srv/SetParameters.srv"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
   DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS
 )

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files

--- a/rcl_interfaces/msg/ParameterEvent.msg
+++ b/rcl_interfaces/msg/ParameterEvent.msg
@@ -3,6 +3,8 @@
 # A specific parameter name can only be in one of the three sets.
 
 RclHeader header
+# Name of the node that requested the parameter change
+string node_req
 Parameter[] new_parameters
 Parameter[] changed_parameters
 Parameter[] deleted_parameters

--- a/rcl_interfaces/msg/ParameterEvent.msg
+++ b/rcl_interfaces/msg/ParameterEvent.msg
@@ -4,7 +4,7 @@
 
 RclHeader rcl_header
 # Name of the node that requested the parameter change
-string node_req
+string request_origin
 Parameter[] new_parameters
 Parameter[] changed_parameters
 Parameter[] deleted_parameters

--- a/rcl_interfaces/msg/ParameterEvent.msg
+++ b/rcl_interfaces/msg/ParameterEvent.msg
@@ -2,6 +2,7 @@
 # It was an atomic update.
 # A specific parameter name can only be in one of the three sets.
 
+RclHeader header
 Parameter[] new_parameters
 Parameter[] changed_parameters
 Parameter[] deleted_parameters

--- a/rcl_interfaces/msg/ParameterEvent.msg
+++ b/rcl_interfaces/msg/ParameterEvent.msg
@@ -2,7 +2,7 @@
 # It was an atomic update.
 # A specific parameter name can only be in one of the three sets.
 
-RclHeader header
+RclHeader rcl_header
 # Name of the node that requested the parameter change
 string node_req
 Parameter[] new_parameters

--- a/rcl_interfaces/msg/ParameterEventDescriptors.msg
+++ b/rcl_interfaces/msg/ParameterEventDescriptors.msg
@@ -2,7 +2,7 @@
 # It was an atomic update.
 # A specific parameter name can only be in one of the three sets.
 
-RclHeader header
+RclHeader rcl_header
 # Name of the node that requested the parameter change
 string node_req
 ParameterDescriptor[] new_parameters

--- a/rcl_interfaces/msg/ParameterEventDescriptors.msg
+++ b/rcl_interfaces/msg/ParameterEventDescriptors.msg
@@ -3,6 +3,8 @@
 # A specific parameter name can only be in one of the three sets.
 
 RclHeader header
+# Name of the node that requested the parameter change
+string node_req
 ParameterDescriptor[] new_parameters
 ParameterDescriptor[] changed_parameters
 ParameterDescriptor[] deleted_parameters

--- a/rcl_interfaces/msg/ParameterEventDescriptors.msg
+++ b/rcl_interfaces/msg/ParameterEventDescriptors.msg
@@ -2,6 +2,7 @@
 # It was an atomic update.
 # A specific parameter name can only be in one of the three sets.
 
+RclHeader header
 ParameterDescriptor[] new_parameters
 ParameterDescriptor[] changed_parameters
 ParameterDescriptor[] deleted_parameters

--- a/rcl_interfaces/msg/ParameterEventDescriptors.msg
+++ b/rcl_interfaces/msg/ParameterEventDescriptors.msg
@@ -4,7 +4,7 @@
 
 RclHeader rcl_header
 # Name of the node that requested the parameter change
-string node_req
+string request_origin
 ParameterDescriptor[] new_parameters
 ParameterDescriptor[] changed_parameters
 ParameterDescriptor[] deleted_parameters

--- a/rcl_interfaces/msg/RclHeader.msg
+++ b/rcl_interfaces/msg/RclHeader.msg
@@ -1,5 +1,3 @@
 builtin_interfaces/Time stamp
 # A fully qualified ROS node name
-string sender_node_name
-
-# TODO(mikaelarguedas) consider a receiver node name as well
+string node

--- a/rcl_interfaces/msg/RclHeader.msg
+++ b/rcl_interfaces/msg/RclHeader.msg
@@ -1,0 +1,5 @@
+builtin_interfaces/Time stamp
+# A fully qualified ROS node name
+string sender_node_name
+
+# TODO(mikaelarguedas) consider a receiver node name as well

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -13,6 +13,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Defines a new rcl message including a string for a node fully qualified name and a timestamp: https://github.com/ros2/rcl_interfaces/commit/e57980f4dc445b2c76a01215034c563bcb3dab98
And use this new massage as a header for ParameterEvent and ParameterEventDescriptor messages: https://github.com/ros2/rcl_interfaces/commit/6a16d7f8261ad1abb52409c5992895ba443f98bc
I'm open to feedback regarding the content of the message (fields, field names or message name).

This includes the commits of #26 but they should be merged soon