### PR TITLE
Add read_only parameter metadata

### DIFF
--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -2,5 +2,7 @@
 
 string name
 uint8 type # Enum defined in ParameterType.msg
+# If 'false' then the value cannot change after it has been initialized
+bool mutable_after_initialization true
 
 # TODO: add additional meta data

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -2,7 +2,7 @@
 
 string name
 uint8 type # Enum defined in ParameterType.msg
-# If 'false' then the value cannot change after it has been initialized
-bool mutable_after_initialization true
+# If 'true' then the value cannot change after it has been initialized
+bool read_only false
 
 # TODO: add additional meta data


### PR DESCRIPTION
WIP until there is code in rclcpp supporting this. Adds a boolean indicating if a parameter is allowed to change after it has been initialized. The default is `true`. If `false` then the parameter can be set via yaml passed to the node, but it's value may not be changed for the life of the node.

connects to ros2/rclcpp#495