### PR TITLE
Only install the Python messages if PYTHON_INSTALL_DIR is defined

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -42,8 +42,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-install(DIRECTORY src/test_msgs
-  DESTINATION "${PYTHON_INSTALL_DIR}/")
+if(DEFINED PYTHON_INSTALL_DIR)
+  install(DIRECTORY src/test_msgs
+    DESTINATION "${PYTHON_INSTALL_DIR}/")
+endif()
 
 install(DIRECTORY include/
   DESTINATION include)


### PR DESCRIPTION
This avoids installing the messages if Python does not exist (e.g. when building for Android, see https://github.com/esteve/ros2_java/issues/44)