### PR TITLE
Allow nanosec < 0

### DIFF
--- a/builtin_interfaces/msg/Duration.msg
+++ b/builtin_interfaces/msg/Duration.msg
@@ -1,2 +1,4 @@
+# The length of a duration is sec and nanosec added together.
+# abs(length) can be less than abs(sec) if the sign of nanosec differs from sec.
 int32 sec
-uint32 nanosec
+int32 nanosec


### PR DESCRIPTION
While fixing an issue found in ros2/rclcpp#525 I noticed the `nanosec` is unsigned. I'm not sure what this is supposed to mean. Does `nanosec` always have the same sign as `sec`, or is it always positive?

Code in rclcpp just adds the two together. However, ros2/rcutils#79 was opened to prevent mixing of signed/unsigned types. This PR makes `nanosec` signed, and adds a comment saying the two fields are to be combined by addition.

CI on ros2/rclcpp#527