### PR TITLE
Add action_msgs package

### DIFF
--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(action_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/GoalStatus.msg"
+  "msg/GoalStatusArray.msg"
+  "msg/UUID.msg"
+)
+set(srv_files
+  "srv/CancelGoal.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES builtin_interfaces
+  ADD_LINTER_TESTS
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -15,9 +15,9 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
+  "msg/GoalInfo.msg"
   "msg/GoalStatus.msg"
   "msg/GoalStatusArray.msg"
-  "msg/UUID.msg"
 )
 set(srv_files
   "srv/CancelGoal.srv"

--- a/action_msgs/msg/GoalInfo.msg
+++ b/action_msgs/msg/GoalInfo.msg
@@ -1,0 +1,6 @@
+# Goal ID
+# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
+uint8[16] uuid
+
+# Time when the goal was accepted
+builtin_interfaces/Time stamp

--- a/action_msgs/msg/GoalStatus.msg
+++ b/action_msgs/msg/GoalStatus.msg
@@ -1,18 +1,15 @@
 # An action goal can be in one of these states after it is accepted by an action server.
 # For more information, see http://design.ros2.org/articles/actions.html
-uint8 STATUS_ACCEPTED  = 0
-uint8 STATUS_EXECUTING = 1
-uint8 STATUS_CANCELING = 2
-uint8 STATUS_SUCCEEDED = 3
-uint8 STATUS_CANCELED  = 4
-uint8 STATUS_ABORTED   = 5
+int8 STATUS_UNKNOWN   = 0
+int8 STATUS_ACCEPTED  = 1
+int8 STATUS_EXECUTING = 2
+int8 STATUS_CANCELING = 3
+int8 STATUS_SUCCEEDED = 4
+int8 STATUS_CANCELED  = 5
+int8 STATUS_ABORTED   = 6
 
-# Goal ID
-# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
-UUID goal_id
-
-# Time when the goal was accepted
-builtin_interfaces/Time stamp
+# Goal info (contains ID and timestamp)
+GoalInfo goal_info
 
 # Goal status
-uint8 status
+int8 status

--- a/action_msgs/msg/GoalStatus.msg
+++ b/action_msgs/msg/GoalStatus.msg
@@ -1,0 +1,18 @@
+# An action goal can be in one of these states after it is accepted by an action server.
+# For more information, see http://design.ros2.org/articles/actions.html
+uint8 STATUS_ACCEPTED  = 0
+uint8 STATUS_EXECUTING = 1
+uint8 STATUS_CANCELING = 2
+uint8 STATUS_SUCCEEDED = 3
+uint8 STATUS_CANCELED  = 4
+uint8 STATUS_ABORTED   = 5
+
+# Goal ID
+# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
+UUID goal_id
+
+# Time when the goal was accepted
+builtin_interfaces/Time stamp
+
+# Goal status
+uint8 status

--- a/action_msgs/msg/GoalStatusArray.msg
+++ b/action_msgs/msg/GoalStatusArray.msg
@@ -1,0 +1,2 @@
+# An array of goal statuses
+GoalStatus[] status_list

--- a/action_msgs/msg/UUID.msg
+++ b/action_msgs/msg/UUID.msg
@@ -1,2 +1,0 @@
-# TODO(jacobperron): Remove UUID.msg in favor of ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
-uint8[16] uuid

--- a/action_msgs/msg/UUID.msg
+++ b/action_msgs/msg/UUID.msg
@@ -1,0 +1,2 @@
+# TODO(jacobperron): Remove UUID.msg in favor of ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
+uint8[16] uuid

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -12,9 +12,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
+  <depend>builtin_interfaces</depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>action_msgs</name>
+  <version>0.5.0</version>
+  <description>Messages and service definitions common among all ROS actions.</description>
+  <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="jacob@openrobotics.org">Jacob Perron</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -1,0 +1,16 @@
+# Cancel one or more goals with the following policy:
+#
+# - If the goal ID is zero and timestamp is zero, cancel all goals.
+# - If the goal ID is zero and timestamp is not zero, cancel all goals accepted
+#   at or before the timestamp.
+# - If the goal ID is not zero and timestamp is zero, cancel the goal with the
+#   given ID regardless of the time it was accepted.
+# - If the goal ID is not zero and timestamp is not zero, cancel the goal with
+#   the given ID and all goals accepted at or before the timestamp.
+#
+# Goal ID
+# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
+UUID goal_id
+builtin_interfaces/Time stamp
+---
+UUID[] goals_canceling

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -7,10 +7,9 @@
 #   given ID regardless of the time it was accepted.
 # - If the goal ID is not zero and timestamp is not zero, cancel the goal with
 #   the given ID and all goals accepted at or before the timestamp.
-#
-# Goal ID
-# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
-UUID goal_id
-builtin_interfaces/Time stamp
+
+# Goal info containing an ID and timestamp
+GoalInfo goal_info
 ---
-UUID[] goals_canceling
+# Goals that accepted the cancel request
+GoalInfo[] goals_canceling


### PR DESCRIPTION
Contains common message and service definitions for all ROS actions.

Messages:
- GoalStatus.msg - Contains a goal ID, timestamp, and status.
- GoalStatusArray.msg - An array of GoalStatus.msg.
- UUID.msg - Type of goal IDs; this is temporary until we port the existing uuid_msgs (see TODOs).

Service:
- CancelGoal.srv - API for canceling goals describing the cancel policy.

Resolves #40 