### PR TITLE
Add test message for dynamic array of static arrays

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ set(msg_files
   "msg/DynamicArrayNested.msg"
   "msg/DynamicArrayPrimitives.msg"
   "msg/DynamicArrayPrimitivesNested.msg"
+  "msg/DynamicArrayStaticArrayPrimitivesNested.msg"
   "msg/Empty.msg"
   "msg/Nested.msg"
   "msg/Primitives.msg"

--- a/test_msgs/msg/DynamicArrayStaticArrayPrimitivesNested.msg
+++ b/test_msgs/msg/DynamicArrayStaticArrayPrimitivesNested.msg
@@ -1,0 +1,1 @@
+StaticArrayPrimitives[] dynamic_array_static_array_primitive_values


### PR DESCRIPTION
Connects to #42 

This is a test message confirming issue #42 is resolved by ros2/rosidl#307.

CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5328)](http://ci.ros2.org/job/ci_linux/5328/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2064)](http://ci.ros2.org/job/ci_linux-aarch64/2064/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4427)](http://ci.ros2.org/job/ci_osx/4427/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5295)](http://ci.ros2.org/job/ci_windows/5295/)