### PR TITLE
Add message fixture for DynamicArrayStaticArrayPrimitivesNested

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -41,6 +41,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
 if(DEFINED PYTHON_INSTALL_DIR)
   install(DIRECTORY src/test_msgs
     DESTINATION "${PYTHON_INSTALL_DIR}/")

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -138,16 +138,16 @@ get_messages_static_array_primitives()
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     msg->int8_values = {{
-      0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
+        0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
     msg->uint8_values = {{0, (std::numeric_limits<uint8_t>::max)(), 0}};
     msg->int16_values = {{
-      0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
+        0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
     msg->uint16_values = {{0, (std::numeric_limits<uint16_t>::max)(), 0}};
     msg->int32_values = {{
-      static_cast<int32_t>(0),
-      (std::numeric_limits<int32_t>::max)(),
-      (std::numeric_limits<int32_t>::min)()
-    }};
+        static_cast<int32_t>(0),
+        (std::numeric_limits<int32_t>::max)(),
+        (std::numeric_limits<int32_t>::min)()
+      }};
     msg->uint32_values = {{0, (std::numeric_limits<uint32_t>::max)(), 0}};
     msg->int64_values[0] = 0;
     msg->int64_values[1] = (std::numeric_limits<int64_t>::max)();
@@ -209,17 +209,17 @@ get_messages_dynamic_array_primitives()
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     msg->int8_values = {{
-      0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
+        0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
     msg->uint8_values = {{0, (std::numeric_limits<uint8_t>::max)()}};
     msg->int16_values = {{
-      0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
+        0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
     msg->uint16_values = {{0, (std::numeric_limits<uint16_t>::max)()}};
     // The narrowing static cast is required to avoid build errors on Windows.
     msg->int32_values = {{
-      static_cast<int32_t>(0),
-      (std::numeric_limits<int32_t>::max)(),
-      (std::numeric_limits<int32_t>::min)()
-    }};
+        static_cast<int32_t>(0),
+        (std::numeric_limits<int32_t>::max)(),
+        (std::numeric_limits<int32_t>::min)()
+      }};
     msg->uint32_values = {{0, (std::numeric_limits<uint32_t>::max)()}};
     msg->int64_values.resize(3);
     msg->int64_values[0] = 0;
@@ -301,8 +301,7 @@ get_messages_dynamic_array_static_array_primitives_nested()
   auto msg = std::make_shared<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>();
   std::vector<test_msgs::msg::StaticArrayPrimitives::SharedPtr> primitive_msgs =
     get_messages_static_array_primitives();
-  for (size_t i = 0; i < primitive_msgs.size(); ++i)
-  {
+  for (size_t i = 0; i < primitive_msgs.size(); ++i) {
     msg->dynamic_array_static_array_primitive_values.push_back(*primitive_msgs[i]);
   }
   messages.push_back(msg);
@@ -321,17 +320,17 @@ get_messages_bounded_array_primitives()
     msg->float32_values = {{0.0f, 1.125f, -2.125f}};
     msg->float64_values = {{0, 1.125, -2.125}};
     msg->int8_values = {{
-      0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
+        0, (std::numeric_limits<int8_t>::max)(), (std::numeric_limits<int8_t>::min)()}};
     msg->uint8_values = {{0, 1, (std::numeric_limits<uint8_t>::max)()}};
     msg->int16_values = {{
-      0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
+        0, (std::numeric_limits<int16_t>::max)(), (std::numeric_limits<int16_t>::min)()}};
     msg->uint16_values = {{0, 1, (std::numeric_limits<uint16_t>::max)()}};
     // The narrowing static cast is required to avoid build errors on Windows.
     msg->int32_values = {{
-      static_cast<int32_t>(0),
-      (std::numeric_limits<int32_t>::max)(),
-      (std::numeric_limits<int32_t>::min)()
-    }};
+        static_cast<int32_t>(0),
+        (std::numeric_limits<int32_t>::max)(),
+        (std::numeric_limits<int32_t>::min)()
+      }};
     msg->uint32_values = {{0, 1, (std::numeric_limits<uint32_t>::max)()}};
     msg->int64_values.resize(3);
     msg->int64_values[0] = 0;

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -26,6 +26,7 @@
 #include "test_msgs/msg/dynamic_array_nested.hpp"
 #include "test_msgs/msg/dynamic_array_primitives.hpp"
 #include "test_msgs/msg/dynamic_array_primitives_nested.hpp"
+#include "test_msgs/msg/dynamic_array_static_array_primitives_nested.hpp"
 #include "test_msgs/msg/empty.hpp"
 #include "test_msgs/msg/nested.hpp"
 #include "test_msgs/msg/primitives.hpp"
@@ -287,6 +288,22 @@ get_messages_dynamic_array_primitives_nested()
   auto msg = std::make_shared<test_msgs::msg::DynamicArrayPrimitivesNested>();
   for (size_t i = 0; i < primitive_msgs.size(); ++i) {
     msg->dynamic_array_primitive_values.push_back(*primitive_msgs[i]);
+  }
+  messages.push_back(msg);
+  return messages;
+}
+
+std::vector<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested::SharedPtr>
+get_messages_dynamic_array_static_array_primitives_nested()
+{
+  std::vector<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested::SharedPtr> messages;
+
+  auto msg = std::make_shared<test_msgs::msg::DynamicArrayStaticArrayPrimitivesNested>();
+  std::vector<test_msgs::msg::StaticArrayPrimitives::SharedPtr> primitive_msgs =
+    get_messages_static_array_primitives();
+  for (size_t i = 0; i < primitive_msgs.size(); ++i)
+  {
+    msg->dynamic_array_static_array_primitive_values.push_back(*primitive_msgs[i]);
   }
   messages.push_back(msg);
   return messages;

--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -18,6 +18,7 @@ from test_msgs.msg import Builtins
 from test_msgs.msg import DynamicArrayNested
 from test_msgs.msg import DynamicArrayPrimitives
 from test_msgs.msg import DynamicArrayPrimitivesNested
+from test_msgs.msg import DynamicArrayStaticArrayPrimitivesNested
 from test_msgs.msg import Empty
 from test_msgs.msg import Nested
 from test_msgs.msg import Primitives
@@ -273,6 +274,16 @@ def get_msg_dynamic_array_nested():
     return [msg]
 
 
+def get_msg_dynamic_array_static_array_primitives_nested():
+    primitives_msgs = get_msg_static_array_primitives()
+
+    msg = DynamicArrayStaticArrayPrimitivesNested()
+    for primitives_msg in primitives_msgs:
+        msg.dynamic_array_static_array_primitive_values.append(primitives_msg)
+
+    return [msg]
+
+
 def get_msg_bounded_array_primitives():
     msgs = []
 
@@ -328,6 +339,8 @@ def get_test_msg(message_name):
         msg = get_msg_dynamic_array_nested()
     elif 'DynamicArrayPrimitivesNested' == message_name:
         msg = get_msg_dynamic_array_primitives_nested()
+    elif 'DynamicArrayStaticArrayPrimitivesNested' == message_name:
+        msg = get_msg_dynamic_array_static_array_primitives_nested()
     elif 'BoundedArrayPrimitives' == message_name:
         msg = get_msg_bounded_array_primitives()
     elif 'BoundedArrayNested' == message_name:


### PR DESCRIPTION
Connects to 
This resolves CI failures introduced by #43.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5361)](http://ci.ros2.org/job/ci_linux/5361/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2088)](http://ci.ros2.org/job/ci_linux-aarch64/2088/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4451)](http://ci.ros2.org/job/ci_osx/4451/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5321)](http://ci.ros2.org/job/ci_windows/5321/)