### PR TITLE
Change UUID type in action_msgs

### DIFF
--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
 
 set(msg_files
   "msg/GoalInfo.msg"
@@ -26,7 +27,7 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces unique_identifier_msgs
   ADD_LINTER_TESTS
 )
 

--- a/action_msgs/msg/GoalInfo.msg
+++ b/action_msgs/msg/GoalInfo.msg
@@ -1,6 +1,5 @@
 # Goal ID
-# TODO(jacobperron): Use a ported version of https://github.com/ros-geographic-info/unique_identifier/blob/master/uuid_msgs
-uint8[16] uuid
+unique_identifier_msgs/UUID goal_id
 
 # Time when the goal was accepted
 builtin_interfaces/Time stamp

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>unique_identifier_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
 
 set(msg_files
   "msg/BoundedArrayPrimitivesNested.msg"
@@ -50,7 +51,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
   ${action_files}
-  DEPENDENCIES builtin_interfaces action_msgs
+  DEPENDENCIES builtin_interfaces action_msgs unique_identifier_msgs
   ADD_LINTER_TESTS
 )
 


### PR DESCRIPTION
This PR is part of a series of three that together close https://github.com/ros2/rcl_interfaces/issues/49
EDIT: Depends on https://github.com/ros2/ros2/pull/609
- Replace the `uint8[16]` field from GoalInfo.msg with `unique_identifier_msgs/uuid`
- Add the required cmake bits