### PR TITLE
remove trailing slash

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 if(DEFINED PYTHON_INSTALL_DIR)
   install(DIRECTORY src/test_msgs
-    DESTINATION "${PYTHON_INSTALL_DIR}/")
+    DESTINATION "${PYTHON_INSTALL_DIR}")
 endif()
 
 install(DIRECTORY include/


### PR DESCRIPTION
Which results in a double slash in the installed path.