### PR TITLE
Description says package is for DDS types

### DIFF
--- a/builtin_interfaces/package.xml
+++ b/builtin_interfaces/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>builtin_interfaces</name>
   <version>0.6.2</version>
-  <description>A package containing builtin message and service definitions.</description>
+  <description>A package containing message and service definitions for types defined in the OMG IDL Platform Specific Model.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
This PR documents what builtin_interfaces is for. However, I'm not sure what I added is correct. The only place I've seen that says `builtin_interface` is for DDS types is this comment https://github.com/ros2/rcl_interfaces/pull/41#issuecomment-433193951 ; however, I didn't find "built in" types in the OMG DDS 1.4 spec. I did see Duration and Time were defined in section 2.3 the Platform Specific Model, so I added that as the description.