### PR TITLE
Add composition_interfaces

### DIFF
--- a/composition_interfaces/CMakeLists.txt
+++ b/composition_interfaces/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(composition_interfaces)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/LoadNode.srv"
+  "srv/ListNodes.srv"
+  "srv/UnloadNode.srv"
+  DEPENDENCIES rcl_interfaces
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/composition_interfaces/package.xml
+++ b/composition_interfaces/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>composition_interfaces</name>
+  <version>0.6.2</version>
+  <description>A package containing message and service definitions for managing composable nodes in a container process.</description>
+  <maintainer email="sloretz@osrfoundation.org">Shane Loretz</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>rcl_interfaces</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/composition_interfaces/srv/ListNodes.srv
+++ b/composition_interfaces/srv/ListNodes.srv
@@ -1,0 +1,5 @@
+---
+# List of full node names including namespace
+string[] full_node_names
+# corresponding unique ids (must have same length as full_node_names)
+uint64[] unique_ids

--- a/composition_interfaces/srv/LoadNode.srv
+++ b/composition_interfaces/srv/LoadNode.srv
@@ -1,0 +1,28 @@
+# A ROS package the composable node can be found in
+string package_name
+# a plugin within that package
+string plugin_name
+
+# Name the composable node should use, or empty to use the node's default name
+string node_name
+# Namespace the composable node should use, or empty to use the node's default namespace
+string node_namespace
+# Values from message rcl_interfaces/Log
+uint8 log_level
+# Remap rules
+# TODO(sloretz) rcl_interfaces message for remap rules?
+string[] remap_rules
+# Parameters to set
+rcl_interfaces/Parameter[] parameters
+
+# key/value arguments that are specific to a type of container process
+rcl_interfaces/Parameter[] extra_arguments
+---
+# True if the node was successfully loaded
+bool success
+# Human readable error message if success is false, else empty string
+string error_messsage
+# Name of the loaded composable node (including namespace)
+string full_node_name
+# A unique identifier for the loaded node
+uint64 unique_id

--- a/composition_interfaces/srv/UnloadNode.srv
+++ b/composition_interfaces/srv/UnloadNode.srv
@@ -1,0 +1,7 @@
+# Container specific unique id of a loaded node
+uint64 unique_id
+---
+# True if the node existed and was unloaded
+bool success
+# Human readable error message if success is false, else empty string
+string error_messsage


### PR DESCRIPTION
This adds services defined in ros2/design#206 to a new package called `composition_interfaces`. The intent is both `launch_ros` and container packages (`rclcpp_composition`?) would use the services from this package to interact.