### PR TITLE
Add mapping file for ROS 1 bridge

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -36,6 +36,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   DEPENDENCIES builtin_interfaces
 )
 
+install(FILES mapping_rules.yaml DESTINATION share/${PROJECT_NAME})
+
 # this must happen before the invocation of ament_package()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rcl_interfaces/mapping_rules.yaml
+++ b/rcl_interfaces/mapping_rules.yaml
@@ -11,4 +11,3 @@
     file: 'file'
     function: 'function'
     line: 'line'
-  

--- a/rcl_interfaces/mapping_rules.yaml
+++ b/rcl_interfaces/mapping_rules.yaml
@@ -1,0 +1,14 @@
+-
+  ros1_package_name: 'rosgraph_msgs'
+  ros1_message_name: 'Log'
+  ros2_package_name: 'rcl_interfaces'
+  ros2_message_name: 'Log'
+  fields_1_to_2:
+    header.stamp: 'stamp'
+    level: 'level'
+    name: 'name'
+    msg: 'msg'
+    file: 'file'
+    function: 'function'
+    line: 'line'
+  

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -24,5 +24,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+     <ros1_bridge mapping_rules="mapping_rules.yaml"/>
   </export>
 </package>


### PR DESCRIPTION
Signed-off-by: Juan Rodriguez Hortala <hortala@amazon.com>

This change add a `ros1_bridge` mapping file to convert between ROS 1 and ROS 2 logging messages. This change should fix https://github.com/ros2/ros1_bridge/issues/159 when combined with https://github.com/ros2/ros1_bridge/pull/174. For `rmw_fastrtps` this will also require a fix for https://github.com/ros2/rcl_interfaces/issues/61