### PR TITLE
Parameters support ranges

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(builtin_interfaces REQUIRED)
 # ament_export_dependencies(rcl_interfaces)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/FloatingPointRange.msg"
+  "msg/IntegerRange.msg"
   "msg/IntraProcessMessage.msg"
   "msg/ListParametersResult.msg"
   "msg/Log.msg"
@@ -27,8 +29,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ParameterType.msg"
   "msg/ParameterValue.msg"
   "msg/SetParametersResult.msg"
-  "msg/FloatingPointRange.msg"
-  "msg/IntegerRange.msg"
   "srv/DescribeParameters.srv"
   "srv/GetParameters.srv"
   "srv/GetParameterTypes.srv"

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -27,6 +27,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ParameterType.msg"
   "msg/ParameterValue.msg"
   "msg/SetParametersResult.msg"
+  "msg/FloatingPointRange.msg"
+  "msg/IntegerRange.msg"
   "srv/DescribeParameters.srv"
   "srv/GetParameters.srv"
   "srv/GetParameterTypes.srv"

--- a/rcl_interfaces/msg/FloatingPointRange.msg
+++ b/rcl_interfaces/msg/FloatingPointRange.msg
@@ -1,10 +1,10 @@
 # Represents bounds and a step value for a floating point typed parameter.
 
 # Start value for valid values, inclusive.
-double from_value
+float64 from_value
 
 # End value for valid values, inclusive.
-double to_value
+float64 to_value
 
 # Size of valid steps between the from and to bound.
 # Step is considered to be a magnitude, therefore negative values are treated the
@@ -21,4 +21,4 @@ double to_value
 # not a multiple of the step, then the "to" bound will always be a valid value,
 # e.g. if the range is defined as {from_value: 2.0, to_value: 5.0, step: 2.0} then
 # the valid values will be 2.0, 4.0, and 5.0.
-double step
+float64 step

--- a/rcl_interfaces/msg/FloatingPointRange.msg
+++ b/rcl_interfaces/msg/FloatingPointRange.msg
@@ -1,14 +1,24 @@
 # Represents bounds and a step value for a floating point typed parameter.
 
-# Lower bound for valid values, inclusive.
-double minimum_value
+# Start value for valid values, inclusive.
+double from_value
 
-# Upper bound for valid values, inclusive.
-double maximum_value
+# End value for valid values, inclusive.
+double to_value
 
-# Size of valid steps between the lower and upper bound.
-# Step should be positive, and a step of zero implies continuous values.
-# Step size should be less than the distance between the minimum and maximum
-# values, and ideally would be an even multiple of that distance, but that
-# is not required.
+# Size of valid steps between the from and to bound.
+# Step is considered to be a magnitude, therefore negative values are treated the
+# same as positive values, and a step value of zero implies a continuous range of
+# values.
+# Ideally, the step would be less than or equal to the distance between the
+# bounds, as well as an even multiple of the distance between the bounds, but
+# neither are required.
+# If the absolute value of the step is larger than or equal to the distance
+# between the two bounds, then the bounds will be the only valid values,
+# e.g. if the range is defined as {from_value: 1.0, to_value: 2.0, step: 5.0} then
+# the valid values will be 1.0 and 2.0.
+# If the step is less than the distance between the bounds, but the distance is
+# not a multiple of the step, then the "to" bound will always be a valid value,
+# e.g. if the range is defined as {from_value: 2.0, to_value: 5.0, step: 2.0} then
+# the valid values will be 2.0, 4.0, and 5.0.
 double step

--- a/rcl_interfaces/msg/FloatingPointRange.msg
+++ b/rcl_interfaces/msg/FloatingPointRange.msg
@@ -1,0 +1,14 @@
+# Represents bounds and a step value for a floating point typed parameter.
+
+# Lower bound for valid values, inclusive.
+double minimum_value
+
+# Upper bound for valid values, inclusive.
+double maximum_value
+
+# Size of valid steps between the lower and upper bound.
+# Step should be positive, and a step of zero implies continuous values.
+# Step size should be less than the distance between the minimum and maximum
+# values, and ideally would be an even multiple of that distance, but that
+# is not required.
+double step

--- a/rcl_interfaces/msg/IntegerRange.msg
+++ b/rcl_interfaces/msg/IntegerRange.msg
@@ -1,0 +1,15 @@
+# Represents bounds and a step value for an integer typed parameter.
+
+# Lower bound for valid values, inclusive.
+int64 minimum_value
+
+# Upper bound for valid values, inclusive.
+int64 maximum_value
+
+# Size of valid steps between the lower and upper bound.
+# Step should be positive, and a step of zero implies a step size of one, i.e.
+# all integer values between the bounds are valid.
+# Step size should be less than the distance between the minimum and maximum
+# values, and ideally would be an even multiple of that distance, but that
+# is not required.
+int64 step

--- a/rcl_interfaces/msg/IntegerRange.msg
+++ b/rcl_interfaces/msg/IntegerRange.msg
@@ -1,15 +1,22 @@
 # Represents bounds and a step value for an integer typed parameter.
 
-# Lower bound for valid values, inclusive.
-int64 minimum_value
+# Start value for valid values, inclusive.
+int64 from_value
 
-# Upper bound for valid values, inclusive.
-int64 maximum_value
+# End value for valid values, inclusive.
+int64 to_value
 
-# Size of valid steps between the lower and upper bound.
-# Step should be positive, and a step of zero implies a step size of one, i.e.
-# all integer values between the bounds are valid.
-# Step size should be less than the distance between the minimum and maximum
-# values, and ideally would be an even multiple of that distance, but that
-# is not required.
-int64 step
+# Size of valid steps between the from and to bound.
+# A step value of zero implies a continuous range of values.
+# Ideally, the step would be less than or equal to the distance between the
+# bounds, as well as an even multiple of the distance between the bounds, but
+# neither are required.
+# If the absolute value of the step is larger than or equal to the distance
+# between the two bounds, then the bounds will be the only valid values,
+# e.g. if the range is defined as {from_value: 1, to_value: 2, step: 5} then
+# the valid values will be 1 and 2.
+# If the step is less than the distance between the bounds, but the distance is
+# not a multiple of the step, then the "to" bound will always be a valid value,
+# e.g. if the range is defined as {from_value: 2, to_value: 5, step: 2} then
+# the valid values will be 2, 4, and 5.
+uint64 step

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -1,8 +1,9 @@
 # This is the message to communicate a parameter's descriptor.
 
 string name
-uint8 type # Enum defined in ParameterType.msg
-# If 'true' then the value cannot change after it has been initialized
-bool read_only false
 
-# TODO: add additional meta data
+# Enum values are defined in the `ParameterType.msg` message.
+uint8 type
+
+# If 'true' then the value cannot change after it has been initialized.
+bool read_only false

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -30,5 +30,3 @@ FloatingPointRange[<=1] floating_point_range
 # IntegerRange consists of a from_value, a to_value, and a step.
 # FloatingPointRange and IntegerRange are mutually exclusive.
 IntegerRange[<=1] integer_range
-
-# more constraints to follow in the future...

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -5,5 +5,15 @@ string name
 # Enum values are defined in the `ParameterType.msg` message.
 uint8 type
 
+# Parameter constraints
+
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false
+
+# docs...
+FloatingPointRange[<=1] floating_point_range
+
+# docs...
+IntegerRange[<=1] integer_range
+
+# more constraints to follow in the future...

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -19,10 +19,16 @@ string additional_constraints
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false
 
-# docs...
+
+# If any of the following sequences are not empty, then the constraint inside of
+# them apply to this parameter.
+
+# FloatingPointRange consists of a from_value, a to_value, and a step.
+# FloatingPointRange and IntegerRange are mutually exclusive.
 FloatingPointRange[<=1] floating_point_range
 
-# docs...
+# IntegerRange consists of a from_value, a to_value, and a step.
+# FloatingPointRange and IntegerRange are mutually exclusive.
 IntegerRange[<=1] integer_range
 
 # more constraints to follow in the future...

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -5,7 +5,16 @@ string name
 # Enum values are defined in the `ParameterType.msg` message.
 uint8 type
 
+# Description of the parameter, visible from introspection tools.
+string description
+
 # Parameter constraints
+
+# Plain English description of additional constraints which cannot be expressed
+# with the available constraints, e.g. "only prime numbers".
+# By convention, this should only be used to clarify constraints which cannot
+# be completely expressed with the parameter constraints below.
+string additional_constraints
 
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false


### PR DESCRIPTION
Based on the recommendation from @dirk-thomas here: https://github.com/ros2/rcl_interfaces/issues/71#issuecomment-484613435

So that we can iterate on it more effectively. See also the discussion in that issue.

This is currently targeted at the `read_only_parameters` branch because that one adds the `read_only` constraint already, but I will re-target the pull request to `master` once that one is merged.

Connects to #71