### PR TITLE
add description fields in the parameter descriptor

### DIFF
--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -5,7 +5,16 @@ string name
 # Enum values are defined in the `ParameterType.msg` message.
 uint8 type
 
+# Description of the parameter, visible from introspection tools.
+string description
+
 # Parameter constraints
+
+# Plain English description of additional constraints which cannot be expressed
+# with the available constraints, e.g. "only prime numbers".
+# By convention, this should only be used to clarify constraints which cannot
+# be completely expressed with the parameter constraints below.
+string additional_constraints
 
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false


### PR DESCRIPTION
My proposal for strings in the parameter descriptor to allow the programmer to convey some extra information about parameters to the user in a dynamic reconfigure like GUI.