### PR TITLE
Add fields for response code to action_msgs/CancelGoal service

### DIFF
--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -11,25 +11,25 @@
 # Goal info containing an ID and timestamp
 GoalInfo goal_info
 ---
-# Response codes
-# Indicates the request was accepted.
+# Return codes
+# Indicates the request was accepted without any errors.
 # One or more goals have transitioned to the CANCELING state.
 # The goals_canceling list is not empty.
-int8 RESPONSE_OK=0
+int8 ERROR_NONE=0
 # Indicates the request was rejected.
 # No goals have transitioned to the CANCELING state.
 # The goals_canceling list is empty.
-int8 RESPONSE_REJECTED=1
+int8 ERROR_REJECTED=1
 # Indicates the requested goal ID does not exist.
 # No goals have transitioned to the CANCELING state.
 # The goals_canceling list is empty.
-int8 RESPONSE_UNKNOWN_GOAL_ID=2
+int8 ERROR_UNKNOWN_GOAL_ID=2
 # Indicates the goal is not cancelable because it is already in a terminal state.
 # No goals have transitioned to the CANCELING state.
 # The goals_canceling list is empty.
-int8 RESPONSE_GOAL_TERMINATED=3
+int8 ERROR_GOAL_TERMINATED=3
 
-# Reponse code
-int8 response
+# Return code
+int8 return_code
 # Goals that accepted the cancel request
 GoalInfo[] goals_canceling

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -20,12 +20,14 @@ int8 RESPONSE_OK=0
 # No goals have transitioned to the CANCELING state.
 # The goals_canceling list is empty.
 int8 RESPONSE_REJECTED=1
-# Indicates the requested goal ID is invalid.
-# This could be because a goal with the ID is not cancelable (e.g. terminated)
-# or there is no goal that matches the ID.
+# Indicates the requested goal ID does not exist.
 # No goals have transitioned to the CANCELING state.
 # The goals_canceling list is empty.
-int8 RESPONSE_INVALID_GOAL_ID=2
+int8 RESPONSE_UNKNOWN_GOAL_ID=2
+# Indicates the goal is not cancelable because it is already in a terminal state.
+# No goals have transitioned to the CANCELING state.
+# The goals_canceling list is empty.
+int8 RESPONSE_GOAL_TERMINATED=3
 
 # Reponse code
 int8 response

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -14,7 +14,7 @@ GoalInfo goal_info
 # Response codes
 # Indicates the request was accepted.
 # One or more goals have transitioned to the CANCELING state.
-# The goals_canceling list is empty.
+# The goals_canceling list is not empty.
 int8 RESPONSE_OK=0
 # Indicates the request was rejected.
 # No goals have transitioned to the CANCELING state.

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -14,11 +14,11 @@ GoalInfo goal_info
 # Response codes
 # Indicates the request was accepted.
 # One or more goals have transitioned to the CANCELING state.
-# The goals_canceling list should not be empty.
+# The goals_canceling list is empty.
 int8 RESPONSE_OK=0
 # Indicates the request was rejected.
 # No goals have transitioned to the CANCELING state.
-# The goals_canceling list should be empty.
+# The goals_canceling list is empty.
 int8 RESPONSE_REJECTED=1
 # Indicates the requested goal ID is invalid.
 # This could be because a goal with the ID is not cancelable (e.g. terminated)

--- a/action_msgs/srv/CancelGoal.srv
+++ b/action_msgs/srv/CancelGoal.srv
@@ -11,5 +11,23 @@
 # Goal info containing an ID and timestamp
 GoalInfo goal_info
 ---
+# Response codes
+# Indicates the request was accepted.
+# One or more goals have transitioned to the CANCELING state.
+# The goals_canceling list should not be empty.
+int8 RESPONSE_OK=0
+# Indicates the request was rejected.
+# No goals have transitioned to the CANCELING state.
+# The goals_canceling list should be empty.
+int8 RESPONSE_REJECTED=1
+# Indicates the requested goal ID is invalid.
+# This could be because a goal with the ID is not cancelable (e.g. terminated)
+# or there is no goal that matches the ID.
+# No goals have transitioned to the CANCELING state.
+# The goals_canceling list is empty.
+int8 RESPONSE_INVALID_GOAL_ID=2
+
+# Reponse code
+int8 response
 # Goals that accepted the cancel request
 GoalInfo[] goals_canceling


### PR DESCRIPTION
Resolves #63 

Useful for communicating the reason for not accepting a cancel goal request.