### PR TITLE
Add UTF-8 BOM to message_fixtures.hpp file

### DIFF
--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -1,4 +1,6 @@
-﻿// Copyright 2015 Open Source Robotics Foundation, Inc.
+﻿// NOLINT: This file starts with a BOM since it contain non-ASCII characters
+//
+// Copyright 2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+﻿// Copyright 2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Precisely what the title says. Fixes https://github.com/ros2/system_tests/issues/359, replacing https://github.com/ros2/system_tests/pull/362.