### PR TITLE
add test cases for UTF-8 encoded strings

### DIFF
--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -159,6 +159,12 @@ get_messages_strings()
   }
   {
     auto msg = std::make_shared<test_msgs::msg::Strings>();
+    msg->string_value = u8"Hell\u00F6 W\u00F6rld!";  // using umlaut
+    msg->bounded_string_value = u8"Hell\u00F6 W\u00F6rld!";  // using umlaut
+    messages.push_back(msg);
+  }
+  {
+    auto msg = std::make_shared<test_msgs::msg::Strings>();
     msg->string_value = "";
     msg->bounded_string_value = "";
     for (size_t i = 0; i < 20000; ++i) {

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -141,6 +141,11 @@ def get_msg_strings():
     msgs.append(msg)
 
     msg = Strings()
+    msg.string_value = 'Hellö Wörld!'
+    msg.bounded_string_value = 'Hellö Wörld!'
+    msgs.append(msg)
+
+    msg = Strings()
     msg.string_value = ''
     # check strings longer then 255 characters
     for i in range(20000):


### PR DESCRIPTION
Adds test cases with non-ASCII characters in string fields covering ros2/rosidl_python#57.