### PR TITLE
Remove unused ParameterEventDescriptors.msg

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -23,7 +23,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ListParametersResult.msg"
   "msg/Log.msg"
   "msg/ParameterDescriptor.msg"
-  "msg/ParameterEventDescriptors.msg"
   "msg/ParameterEvent.msg"
   "msg/Parameter.msg"
   "msg/ParameterType.msg"

--- a/rcl_interfaces/msg/ParameterEventDescriptors.msg
+++ b/rcl_interfaces/msg/ParameterEventDescriptors.msg
@@ -1,7 +1,0 @@
-# This message contains descriptors of a parameter event.
-# It was an atomic update.
-# A specific parameter name can only be in one of the three sets.
-
-ParameterDescriptor[] new_parameters
-ParameterDescriptor[] changed_parameters
-ParameterDescriptor[] deleted_parameters


### PR DESCRIPTION
This message file was added several years ago and is not currently in use. Instead of adding documentation for an unused feature, I figured it would be better to just remove the message for now.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9708)](http://ci.ros2.org/job/ci_linux/9708/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5364)](http://ci.ros2.org/job/ci_linux-aarch64/5364/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7913)](http://ci.ros2.org/job/ci_osx/7913/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9602)](http://ci.ros2.org/job/ci_windows/9602/)