### PR TITLE
Primary state error transitions

### DIFF
--- a/lifecycle_msgs/msg/Transition.msg
+++ b/lifecycle_msgs/msg/Transition.msg
@@ -44,6 +44,14 @@ uint8 TRANSITION_ON_ERROR_SUCCESS = 60
 uint8 TRANSITION_ON_ERROR_FAILURE = 61
 uint8 TRANSITION_ON_ERROR_ERROR = 62
 
+# These transitions are internally
+# available to the lifecycle node to
+# be called when an error arises during
+# normal operation that causes the node
+# to need reconfiguration.
+uint8 TRANSITION_ACTIVE_ERROR = 63
+uint8 TRANSITION_INACTIVE_ERROR = 64
+
 # These return values ought to be set
 # as a return value for each callback.
 # Depending on which return value,


### PR DESCRIPTION
In the [node_lifecycle design document](http://design.ros2.org/articles/node_lifecycle.html), it shows the state machine for lifecycle nodes:
![life_cycle_sm](https://user-images.githubusercontent.com/4563047/79162521-0c6f8d80-7da3-11ea-919f-05b5d338328e.png)
The red X for Error Raised on the active state indicates that the original author intended a transition from active to errorProcessing. This PR and the related ones to follow in rcl and rclcpp implement that functionality, while the related PR in demos shows its use.

I also submit that there should be a similar transition from inactive to errorProcessing.

My use case:
I have a lifecycle node that communicates with a piece of hardware that needs to be configured before use and thus a lifecycle node was an obvious choice. For safety reasons, however, the hardware can be hard-killed and reset, while the machine on which the ros node runs stays on. The node can recognize that the hardware has been power-reset. If I am in the active state, I need to go directly to the unconfigured state. Without the error transition, I need a bunch of special logic in the `on_deactivate` and `on_cleanup` callbacks, because if I self-transition in the node with `deactivate` without extra logic, I will be calling functions on the unconfigured hardware. Anyway, I think the error transition more correctly describes what happens. I also prefer to keep the externally available transitions external to the node.

Similarly, if my hardware is killed while the node is inactive, I will not want to call the cleanup code that could try to set parameters on the unconfigured hardware, I want to go through the error transition instead.

My original question asked to the community on the answers page is [here](https://answers.ros.org/question/348583/ros-2-lifecycle-node-self-transitioning/?answer=349046#post-id-349046). When I asked it, I did not find that [this functionality was also asked for on the answers page by another user](https://answers.ros.org/question/302178/ros2-managed-node-triggering-an-error-from-primary-state/) and that [issue 547 on rclcpp](https://github.com/ros2/rclcpp/issues/547) had been filed until more searching.