### PR TITLE
Add action_msgs::msg::GoalStatus::STATUS_PREEMPTED

### DIFF
--- a/action_msgs/msg/GoalStatus.msg
+++ b/action_msgs/msg/GoalStatus.msg
@@ -25,6 +25,9 @@ int8 STATUS_CANCELED  = 5
 # The goal was terminated by the action server without an external request.
 int8 STATUS_ABORTED   = 6
 
+# The goal was preempted by the client.
+int8 STATUS_PREEMPTED = 7
+
 # Goal info (contains ID and timestamp).
 GoalInfo goal_info
 


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

As per https://github.com/ros2/rclcpp/issues/1104 and the corresponding PR https://github.com/ros2/rclcpp/pull/1117, this PR adds `STATUS_PREEMPTED` to `action_msgs/GoalStatus` to refer to a goal that was preempted by the client.