### PR TITLE
test_msgs: remove dependency action_msgs from package.xml?

### DIFF
--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -14,7 +14,6 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>test_interface_files</build_depend>
 
-  <depend>action_msgs</depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
This pull request is more a question than an actual request to merge my patch: Why is the dependency on `action_msgs` needed? `action_msgs` is not mentioned anywhere within `test_msgs`. Or must any interface package that defines actions declare a dependency on `action_msgs`?

This seems to be related to https://github.com/ros2/rosidl/pull/369, https://github.com/ros2/rcl_interfaces/pull/81 and other pull requests following https://github.com/ros2/rosidl/pull/369. In my understanding the explicit `action_msgs` dependency in `package.xml` should have been removed, too. But then the build can fail if the respective package is in the same workspace as `action_msgs`? I assume it just does not matter for most packages which are not part of the core ROS 2 distribution and are only ever built in an overlay workspace, and even if not it is unlikely to trigger a build error because `action_msgs` is built before most other packages anyway due to lexical ordering.

If `<depend>action_msgs</depend>` is indeed required for all packages which have actions, `rosidl_generate_interfaces()` should probably warn if that is not the case even if `find_package(action_msgs)` succeeds? I also could not find a hint about `action_msgs` in user-facing documentation or tutorials, e.g. [About ROS 2 interfaces](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/), [Expanding on ROS 2 interfaces](https://index.ros.org/doc/ros2/Tutorials/Single-Package-Define-And-Use-Interface/) or [Understanding ROS 2 actions](https://index.ros.org/doc/ros2/Tutorials/Understanding-ROS2-Actions/).

I noticed when working on https://github.com/orocos/rtt_ros2_integration/pull/12, where the dependencies of an interface package are translated to dependencies of the respective generated Orocos typekit package. `test_msgs` is used for unit tests there.