### PR TITLE
Update all package QDs to QL2.

### DIFF
--- a/action_msgs/QUALITY_DECLARATION.md
+++ b/action_msgs/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `action_msgs` package
 
 # `action_msgs` Quality Declaration
 
-The package `action_msgs` claims to be in the **Quality Level 3** category.
+The package `action_msgs` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,10 +86,10 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`action_msgs` has the following runtime ROS dependencies, which are at or above QL 3:
-* `builtin_interfaces`: [QL 3](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
-* `unique_identifier_msgs`: [QL 3](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
+`action_msgs` has the following runtime ROS dependencies, which are at or above QL 2:
+* `builtin_interfaces`: [QL 2](../builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `unique_identifier_msgs`: [QL 2](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/action_msgs/README.md
+++ b/action_msgs/README.md
@@ -13,4 +13,4 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [CancelGoal](srv/CancelGoal.srv): Cancel Goals either by id and/or timestamp.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/builtin_interfaces/QUALITY_DECLARATION.md
+++ b/builtin_interfaces/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `builtin_interfaces` 
 
 # `builtin_interfaces` Quality Declaration
 
-The package `builtin_interfaces` claims to be in the **Quality Level 3** category.
+The package `builtin_interfaces` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,8 +86,8 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`builtin_interfaces` has the following ROS dependencies, which are at or above QL 3:
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`builtin_interfaces` has the following ROS dependencies, which are at or above QL 2:
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/builtin_interfaces/README.md
+++ b/builtin_interfaces/README.md
@@ -10,4 +10,4 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [Time](msg/Time.msg): Describes a point in time, composed of seconds and nanoseconds components.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/composition_interfaces/QUALITY_DECLARATION.md
+++ b/composition_interfaces/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `composition_interfac
 
 # `composition_interfaces` Quality Declaration
 
-The package `composition_interfaces` claims to be in the **Quality Level 3** category.
+The package `composition_interfaces` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,8 +86,8 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`composition_interfaces` has the following ROS dependencies, which are at or above QL 3:
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`composition_interfaces` has the following ROS dependencies, which are at or above QL 2:
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/composition_interfaces/README.md
+++ b/composition_interfaces/README.md
@@ -10,4 +10,4 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [UnloadNode](srv/UnloadNode.srv): Unload a specified node by its id.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/lifecycle_msgs/QUALITY_DECLARATION.md
+++ b/lifecycle_msgs/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `lifecycle_msgs` pack
 
 # `lifecycle_msgs` Quality Declaration
 
-The package `lifecycle_msgs` claims to be in the **Quality Level 3** category.
+The package `lifecycle_msgs` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,8 +86,8 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`lifecycle_msgs` has the following ROS dependencies, which are at or above QL 3:
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`lifecycle_msgs` has the following ROS dependencies, which are at or above QL 2:
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/lifecycle_msgs/README.md
+++ b/lifecycle_msgs/README.md
@@ -20,4 +20,4 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [GetState](srv/GetState.srv): Request the current lifecycle state of this node.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rcl_interfaces/QUALITY_DECLARATION.md
+++ b/rcl_interfaces/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `rcl_interfaces` pack
 
 # `rcl_interfaces` Quality Declaration
 
-The package `rcl_interfaces` claims to be in the **Quality Level 3** category.
+The package `rcl_interfaces` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -84,9 +84,9 @@ There is an automated test which runs a linter that ensures each file has at lea
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`rcl_interfaces` has the following ROS dependencies, which are at or above QL 3:
-* `builtin_interfaces`: [QL 3](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`rcl_interfaces` has the following ROS dependencies, which are at or above QL 2:
+* `builtin_interfaces`: [QL 2](../builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/rcl_interfaces/README.md
+++ b/rcl_interfaces/README.md
@@ -56,4 +56,4 @@ The ROS API for a node will be as follows inside the node's namespace.
 * [SetParametersAtomically](srv/SetParametersAtomically.srv): Add or change all parameters in a list or none at all.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rosgraph_msgs/QUALITY_DECLARATION.md
+++ b/rosgraph_msgs/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `rosgraph_msgs` packa
 
 # `rosgraph_msgs` Quality Declaration
 
-The package `rosgraph_msgs` claims to be in the **Quality Level 3** category.
+The package `rosgraph_msgs` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,9 +86,9 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`rosgraph_msgs` has the following ROS dependencies, which are at or above QL 3:
-* `builtin_interfaces`: [QL 3](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`rosgraph_msgs` has the following ROS dependencies, which are at or above QL 2:
+* `builtin_interfaces`: [QL 2](../builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/rosgraph_msgs/README.md
+++ b/rosgraph_msgs/README.md
@@ -9,4 +9,4 @@ For more information about ROS 2 interfaces, see [index.ros2.org](https://index.
 * [Clock](msg/Clock.msg): Communicates the current ROS time.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/statistics_msgs/QUALITY_DECLARATION.md
+++ b/statistics_msgs/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `statistics_msgs` pac
 
 # `statistics_msgs` Quality Declaration
 
-The package `statistics_msgs` claims to be in the **Quality Level 3** category.
+The package `statistics_msgs` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -86,9 +86,9 @@ The nightly test can be found at [here](http://build.ros2.org/view/Epr/job/Epr__
 
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
-`statistics_msgs` has the following ROS dependencies, which are at or above QL 3:
-* `builtin_interfaces`: [QL 3](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+`statistics_msgs` has the following ROS dependencies, which are at or above QL 2:
+* `builtin_interfaces`: [QL 2](../builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime`: [QL 2](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/statistics_msgs/README.md
+++ b/statistics_msgs/README.md
@@ -37,4 +37,4 @@ statistics for topics and system resources.
    of collected metrics.
 
 ## Quality Declaration
-This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
Precisely what the title says. Connected to https://github.com/ros2/unique_identifier_msgs/pull/15.

BTW `test_msgs` doesn't have a QD. I'll assume that's so because it's only used for testing.