### PR TITLE
Add boolean in ParameterDescriptor to enforce parameters static typing

### DIFF
--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -21,8 +21,8 @@ string additional_constraints
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false
 
-# If 'true', duck typing is allowed.
-bool allow_duck_typing false
+# If 'true', the parameter is not allowed to change its type.
+bool static_typing true
 
 # If any of the following sequences are not empty, then the constraint inside of
 # them apply to this parameter.

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -21,6 +21,8 @@ string additional_constraints
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false
 
+# If 'true', duck typing is allowed.
+bool allow_duck_typing false
 
 # If any of the following sequences are not empty, then the constraint inside of
 # them apply to this parameter.


### PR DESCRIPTION
Currently parameters can change of type any time, which can be avoided by using a custom parameter callback (e.g. [here](https://github.com/ros2/rclcpp/blob/c88cc649d32cb3a0ca7eb3c2b92d678303adb0d5/rclcpp/src/rclcpp/time_source.cpp#L104)).
When a parameter is changed to an unexpected type, it will usually generate an exception in the code using the parameter (see for example https://github.com/ros2/rclcpp/issues/802), which is undesired.

What users commonly expect is that a parameter not change its type, so it would be good to provide an easy way to ensure that.
The parameter descriptor already contains a [type](https://github.com/ros2/rcl_interfaces/blob/7a6ebaa2064151a48dd189cd514fc7db5d260047/rcl_interfaces/msg/ParameterDescriptor.msg#L3-L7) field, but that is being used to reflect the last type that was set.

The proposal of this PR is to add a field called `static_typing`, when `true` a parameter cannot be changed of type.
In that case, after the parameter is set to a type different than `PARAMETER_NOT_SET`, that type is not allowed to change.
Open questions:
- Should it be possible to declare a parameter with `static_typing=true` and `type=PARAMETER_NOT_SET`?
  I would say no, an `int` parameter should have an int default value provided when declared, and the user override (`--ros-args -p ...`) should match the type of the default value. i.e.:
  ```cpp
  // should raise, initialized with type PARAMETER_NOT_SET and requested static typing
  node->declare_parameter("an_int", rclcpp::ParameterValue(), descriptor_static_typing_true);
  // Okey, and it raises an exception if the user provides an override which is not an integer, e.g.: `-p an_int:=foo`
  node->declare_parameter("an_int", 5, descriptor_static_typing_true);
- Should it be possible to undeclare a parameter when `static_typing=true`? IMO, no.
  Allowing that would actually make a parameter of type `int` behave as an `optional<int>`, and it would still require special care when getting the parameter to avoid errors.

Alternatives:

- Add a `uint8 allowed_type` field in the parameter description, where `PARAMETER_NOT_SET` would allow dynamic typing. There's no big difference with the proposal above.
- Use the old `type` field as the `allowed_type` field described above.
- Add a `uint8[<=10] allowed_types` field (we could use a boolean mask instead of an array). This approach is more flexible, but 99% of the time the user just wants to allow a single type, so not supporting this case doesn't sound important (and can still be achieved with dynamic typing and an user provided parameter callback).