### PR TITLE
test_msgs depend on library targets exported with ament_export_targets instead of ament_export_libraries

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -40,14 +40,14 @@ if(BUILD_TESTING)
   target_include_directories(test_action_typesupport_c_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_c_builds
-    ${_AMENT_EXPORT_LIBRARIES})
+    ${_AMENT_CMAKE_EXPORT_TARGETS})
 
   ament_add_gtest(test_action_typesupport_cpp_builds
     test/test_cpp_type_support.cpp)
   target_include_directories(test_action_typesupport_cpp_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_cpp_builds
-    ${_AMENT_EXPORT_LIBRARIES})
+    ${_AMENT_CMAKE_EXPORT_TARGETS})
 endif()
 
 if(DEFINED PYTHON_INSTALL_DIR)


### PR DESCRIPTION
Part of ament/ament_cmake#365

`test_msgs` has test targets that depend on all library targets created by the rosidl generators. It uses the variable `_AMENT_EXPORT_LIBRARIES` created by `ament_export_libraries()` to get the names of those library targets. This makes it instead depend on `_AMENT_CMAKE_EXPORT_TARGETS` which is created by `ament_export_targets()`.