### PR TITLE
Install headers to include/${PROJECT_NAME} and Depend on rosidl_typesupport_* targets directly

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -20,7 +20,8 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(test_interface_files REQUIRED)
 
-rosidl_generate_interfaces(test_msgs_interfaces
+# TODO(sloretz) Change to test_msgs_interfaces when ros2/rosidl_typesupport#120 is fixed
+rosidl_generate_interfaces(test_msgs
   ${test_interface_files_MSG_FILES}
   ${test_interface_files_SRV_FILES}
   ${test_interface_files_ACTION_FILES}
@@ -31,10 +32,11 @@ rosidl_generate_interfaces(test_msgs_interfaces
   ADD_LINTER_TESTS
 )
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE
+# TODO(sloretz) Change to test_msgs when ros2/rosidl_typesupport#120 is fixed
+add_library(${PROJECT_NAME}_includes INTERFACE)
+target_include_directories(${PROJECT_NAME}_includes INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 ament_export_targets(export_${PROJECT_NAME})
 
@@ -42,8 +44,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  rosidl_get_typesupport_target(c_typesupport_target "test_msgs_interfaces" "rosidl_typesupport_c")
-  rosidl_get_typesupport_target(cpp_typesupport_target "test_msgs_interfaces" "rosidl_typesupport_cpp")
+  rosidl_get_typesupport_target(c_typesupport_target "test_msgs" "rosidl_typesupport_c")
+  rosidl_get_typesupport_target(cpp_typesupport_target "test_msgs" "rosidl_typesupport_cpp")
 
   ament_add_gtest(test_action_typesupport_c_builds
     test/test_c_type_support.cpp)
@@ -62,9 +64,12 @@ if(DEFINED PYTHON_INSTALL_DIR)
 endif()
 
 install(DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})
 
-install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME}_includes EXPORT export_${PROJECT_NAME})
+
+# TODO(sloretz) stop exporting old-style CMake variables in the future
+ament_export_include_directories("include/${PROJECT_NAME}")
 
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(test_interface_files REQUIRED)
 
-rosidl_generate_interfaces(generate_test_msgs
+rosidl_generate_interfaces(test_msgs_interfaces
   ${test_interface_files_MSG_FILES}
   ${test_interface_files_SRV_FILES}
   ${test_interface_files_ACTION_FILES}
@@ -42,8 +42,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  rosidl_get_typesupport_target(c_typesupport_target "generate_test_msgs" "rosidl_typesupport_c")
-  rosidl_get_typesupport_target(cpp_typesupport_target "generate_test_msgs" "rosidl_typesupport_cpp")
+  rosidl_get_typesupport_target(c_typesupport_target "test_msgs_interfaces" "rosidl_typesupport_c")
+  rosidl_get_typesupport_target(cpp_typesupport_target "test_msgs_interfaces" "rosidl_typesupport_cpp")
 
   ament_add_gtest(test_action_typesupport_c_builds
     test/test_c_type_support.cpp)

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -47,15 +47,11 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_action_typesupport_c_builds
     test/test_c_type_support.cpp)
-  target_include_directories(test_action_typesupport_c_builds PRIVATE
-    include)
   target_link_libraries(test_action_typesupport_c_builds
     "${c_typesupport_target}")
 
   ament_add_gtest(test_action_typesupport_cpp_builds
     test/test_cpp_type_support.cpp)
-  target_include_directories(test_action_typesupport_cpp_builds PRIVATE
-    include)
   target_link_libraries(test_action_typesupport_cpp_builds
     "${cpp_typesupport_target}")
 endif()

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -42,19 +42,22 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
+  rosidl_get_typesupport_target(c_typesupport_target "generate_test_msgs" "rosidl_typesupport_c")
+  rosidl_get_typesupport_target(cpp_typesupport_target "generate_test_msgs" "rosidl_typesupport_cpp")
+
   ament_add_gtest(test_action_typesupport_c_builds
     test/test_c_type_support.cpp)
   target_include_directories(test_action_typesupport_c_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_c_builds
-    generate_test_msgs__rosidl_typesupport_c)
+    "${c_typesupport_target}")
 
   ament_add_gtest(test_action_typesupport_cpp_builds
     test/test_cpp_type_support.cpp)
   target_include_directories(test_action_typesupport_cpp_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_cpp_builds
-    generate_test_msgs__rosidl_typesupport_cpp)
+    "${cpp_typesupport_target}")
 endif()
 
 if(DEFINED PYTHON_INSTALL_DIR)

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -31,6 +31,13 @@ rosidl_generate_interfaces(generate_test_msgs
   ADD_LINTER_TESTS
 )
 
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+
+ament_export_targets(export_${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -58,6 +65,7 @@ endif()
 install(DIRECTORY include/
   DESTINATION include)
 
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
+
 ament_export_dependencies(rosidl_default_runtime)
-ament_export_include_directories(include)
 ament_package()

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(test_interface_files REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
+rosidl_generate_interfaces(generate_test_msgs
   ${test_interface_files_MSG_FILES}
   ${test_interface_files_SRV_FILES}
   ${test_interface_files_ACTION_FILES}
@@ -40,14 +40,14 @@ if(BUILD_TESTING)
   target_include_directories(test_action_typesupport_c_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_c_builds
-    ${_AMENT_EXPORT_LIBRARIES})
+    generate_test_msgs__rosidl_typesupport_c)
 
   ament_add_gtest(test_action_typesupport_cpp_builds
     test/test_cpp_type_support.cpp)
   target_include_directories(test_action_typesupport_cpp_builds PRIVATE
     include)
   target_link_libraries(test_action_typesupport_cpp_builds
-    ${_AMENT_EXPORT_LIBRARIES})
+    generate_test_msgs__rosidl_typesupport_cpp)
 endif()
 
 if(DEFINED PYTHON_INSTALL_DIR)


### PR DESCRIPTION
~Part of ament/ament_cmake#365~
Part of ros2/ros2#1150
Requires ros2/rosidl_python#149

This PR makes `test_msgs` depend on the generated `rosidl_typesupport_c` and `rosidl_typesupport_cpp` targets directly instead of depending on an internal ament_cmake variable. Then I made an `INTERFACE` target that exports the include directories ~instead of using `ament_export_include_directories()`~

It also installs headers to `include/${PROJECT_NAME}` to avoid include directory search order issues when overriding packages. ros2/ros2#1150