### PR TITLE
add note that tells read_only parameter can be undeclared.

### DIFF
--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -19,6 +19,7 @@ string description
 string additional_constraints
 
 # If 'true' then the value cannot change after it has been initialized.
+# But parameter still can be undeclared by the node that declared it.
 bool read_only false
 
 # If true, the parameter is allowed to change type.


### PR DESCRIPTION
must be aligned with https://github.com/ros2/rclcpp/pull/1824

note: there is a description about `read_only` parameter in [qos_configurability](http://design.ros2.org/articles/qos_configurability.html), but i do not think that we need to update this section.

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>