### PR TITLE
Make the functions in the header static inline.

### DIFF
--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -36,7 +36,7 @@
 #include "test_msgs/msg/unbounded_sequences.hpp"
 #include "test_msgs/msg/w_strings.hpp"
 
-std::vector<test_msgs::msg::Empty::SharedPtr>
+static inline std::vector<test_msgs::msg::Empty::SharedPtr>
 get_messages_empty()
 {
   std::vector<test_msgs::msg::Empty::SharedPtr> messages;
@@ -45,7 +45,7 @@ get_messages_empty()
   return messages;
 }
 
-std::vector<test_msgs::msg::BasicTypes::SharedPtr>
+static inline std::vector<test_msgs::msg::BasicTypes::SharedPtr>
 get_messages_basic_types()
 {
   std::vector<test_msgs::msg::BasicTypes::SharedPtr> messages;
@@ -120,7 +120,7 @@ get_messages_basic_types()
   return messages;
 }
 
-std::vector<test_msgs::msg::Constants::SharedPtr>
+static inline std::vector<test_msgs::msg::Constants::SharedPtr>
 get_messages_constants()
 {
   std::vector<test_msgs::msg::Constants::SharedPtr> messages;
@@ -131,7 +131,7 @@ get_messages_constants()
   return messages;
 }
 
-std::vector<test_msgs::msg::Defaults::SharedPtr>
+static inline std::vector<test_msgs::msg::Defaults::SharedPtr>
 get_messages_defaults()
 {
   std::vector<test_msgs::msg::Defaults::SharedPtr> messages;
@@ -142,7 +142,7 @@ get_messages_defaults()
   return messages;
 }
 
-std::vector<test_msgs::msg::Strings::SharedPtr>
+static inline std::vector<test_msgs::msg::Strings::SharedPtr>
 get_messages_strings()
 {
   std::vector<test_msgs::msg::Strings::SharedPtr> messages;
@@ -179,7 +179,7 @@ get_messages_strings()
   return messages;
 }
 
-std::vector<test_msgs::msg::Arrays::SharedPtr>
+static inline std::vector<test_msgs::msg::Arrays::SharedPtr>
 get_messages_arrays()
 {
   auto basic_types_msgs = get_messages_basic_types();
@@ -216,7 +216,7 @@ get_messages_arrays()
   return messages;
 }
 
-std::vector<test_msgs::msg::UnboundedSequences::SharedPtr>
+static inline std::vector<test_msgs::msg::UnboundedSequences::SharedPtr>
 get_messages_unbounded_sequences()
 {
   auto basic_types_msgs = get_messages_basic_types();
@@ -342,7 +342,7 @@ get_messages_unbounded_sequences()
   return messages;
 }
 
-std::vector<test_msgs::msg::BoundedPlainSequences::SharedPtr>
+static inline std::vector<test_msgs::msg::BoundedPlainSequences::SharedPtr>
 get_messages_bounded_plain_sequences()
 {
   auto basic_types_msgs = get_messages_basic_types();
@@ -389,7 +389,7 @@ get_messages_bounded_plain_sequences()
   return messages;
 }
 
-std::vector<test_msgs::msg::BoundedSequences::SharedPtr>
+static inline std::vector<test_msgs::msg::BoundedSequences::SharedPtr>
 get_messages_bounded_sequences()
 {
   auto basic_types_msgs = get_messages_basic_types();
@@ -437,7 +437,7 @@ get_messages_bounded_sequences()
   return messages;
 }
 
-std::vector<test_msgs::msg::MultiNested::SharedPtr>
+static inline std::vector<test_msgs::msg::MultiNested::SharedPtr>
 get_messages_multi_nested()
 {
   auto arrays_msgs = get_messages_arrays();
@@ -492,7 +492,7 @@ get_messages_multi_nested()
   return messages;
 }
 
-std::vector<test_msgs::msg::Nested::SharedPtr>
+static inline std::vector<test_msgs::msg::Nested::SharedPtr>
 get_messages_nested()
 {
   std::vector<test_msgs::msg::Nested::SharedPtr> messages;
@@ -505,7 +505,7 @@ get_messages_nested()
   return messages;
 }
 
-std::vector<test_msgs::msg::Builtins::SharedPtr>
+static inline std::vector<test_msgs::msg::Builtins::SharedPtr>
 get_messages_builtins()
 {
   std::vector<test_msgs::msg::Builtins::SharedPtr> messages;
@@ -520,7 +520,7 @@ get_messages_builtins()
   return messages;
 }
 
-std::vector<test_msgs::msg::WStrings::SharedPtr>
+static inline std::vector<test_msgs::msg::WStrings::SharedPtr>
 get_messages_wstrings()
 {
   std::vector<test_msgs::msg::WStrings::SharedPtr> messages;

--- a/test_msgs/include/test_msgs/service_fixtures.hpp
+++ b/test_msgs/include/test_msgs/service_fixtures.hpp
@@ -26,6 +26,7 @@
 #include "test_msgs/srv/empty.hpp"
 
 
+static inline
 std::vector<
   std::pair<
     test_msgs::srv::Empty::Request::SharedPtr,
@@ -48,6 +49,7 @@ get_services_empty()
   return services;
 }
 
+static inline
 std::vector<
   std::pair<
     test_msgs::srv::BasicTypes::Request::SharedPtr,
@@ -139,6 +141,7 @@ get_services_basic_types()
   return services;
 }
 
+static inline
 std::vector<
   std::pair<
     test_msgs::srv::Arrays::Request::SharedPtr,


### PR DESCRIPTION
That way they can be linked to from more than one compilation
unit as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>