### PR TITLE
[service introspection] Add ServiceEvent, ServiceEventInfo, ServiceEventType messages 

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FloatingPointRange.msg"
@@ -25,6 +26,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Parameter.msg"
   "msg/ParameterType.msg"
   "msg/ParameterValue.msg"
+  "msg/ServiceEvent.msg"
+  "msg/ServiceEventType.msg"
   "msg/SetParametersResult.msg"
   "srv/DescribeParameters.srv"
   "srv/GetParameters.srv"
@@ -32,7 +35,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListParameters.srv"
   "srv/SetParametersAtomically.srv"
   "srv/SetParameters.srv"
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces unique_identifier_msgs
 )
 
 install(FILES mapping_rules.yaml DESTINATION share/${PROJECT_NAME})

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -27,6 +27,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ParameterType.msg"
   "msg/ParameterValue.msg"
   "msg/ServiceEvent.msg"
+  "msg/ServiceEventInfo.msg"
   "msg/ServiceEventType.msg"
   "msg/SetParametersResult.msg"
   "srv/DescribeParameters.srv"

--- a/rcl_interfaces/msg/ServiceEvent.msg
+++ b/rcl_interfaces/msg/ServiceEvent.msg
@@ -1,0 +1,20 @@
+# The type of event this message represents
+# See ServiceEventType for possible values
+uint8 event_type
+
+# Timestamp for when the event occurred (sent or received time)
+builtin_interfaces/Time stamp
+
+# Unique identifier for the client that sent the service request
+# Note, this is only unique for the current session
+unique_identifier_msgs/UUID client_id
+
+# Sequence number for the request
+# Combined with the client ID, this creates a unique ID for the service transaction
+int64 sequence_number
+
+string service_name
+string request_type_name
+string response_type_name
+byte[] serialized_request
+byte[] serialized_response

--- a/rcl_interfaces/msg/ServiceEvent.msg
+++ b/rcl_interfaces/msg/ServiceEvent.msg
@@ -14,7 +14,5 @@ unique_identifier_msgs/UUID client_id
 int64 sequence_number
 
 string service_name
-string request_type_name
-string response_type_name
-byte[] serialized_request
-byte[] serialized_response
+string event_name
+byte[] serialized_event

--- a/rcl_interfaces/msg/ServiceEvent.msg
+++ b/rcl_interfaces/msg/ServiceEvent.msg
@@ -1,18 +1,5 @@
-# The type of event this message represents
-# See ServiceEventType for possible values
-uint8 event_type
+# See ServiceEventInfo
+rcl_interfaces/ServiceEventInfo info
 
-# Timestamp for when the event occurred (sent or received time)
-builtin_interfaces/Time stamp
-
-# Unique identifier for the client that sent the service request
-# Note, this is only unique for the current session
-unique_identifier_msgs/UUID client_id
-
-# Sequence number for the request
-# Combined with the client ID, this creates a unique ID for the service transaction
-int64 sequence_number
-
-string service_name
-string event_name
+# Serialized Service_Request/Service_Response message
 byte[] serialized_event

--- a/rcl_interfaces/msg/ServiceEventInfo.msg
+++ b/rcl_interfaces/msg/ServiceEventInfo.msg
@@ -1,0 +1,20 @@
+# The type of event this message represents
+# See ServiceEventType for possible values
+uint8 event_type
+
+# Timestamp for when the event occurred (sent or received time)
+builtin_interfaces/Time stamp
+
+# Unique identifier for the client that sent the service request
+# Note, this is only unique for the current session
+unique_identifier_msgs/UUID client_id
+
+# Sequence number for the request
+# Combined with the client ID, this creates a unique ID for the service transaction
+int64 sequence_number
+
+# Name of the service, i.e. add_two_ints_service
+string service_name
+
+# Name of the service event, i.e. AddTwoInts_Request
+string event_name

--- a/rcl_interfaces/msg/ServiceEventType.msg
+++ b/rcl_interfaces/msg/ServiceEventType.msg
@@ -1,0 +1,14 @@
+# An enumeration of service event types
+# These are used to set the type value in ServiceEvent messages
+
+# A service request was sent by a client
+uint8 REQUEST_SENT=0
+
+# A service request was recieved by a service
+uint8 REQUEST_RECEIVED=1
+
+# A service response was sent by a service
+uint8 RESPONSE_SENT=2
+
+# A service response was received by a client
+uint8 RESPONSE_RECEIVED=3

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>unique_identifier_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
This PR is a prototype for the service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) implementing the proposed single serialized message approach (https://github.com/ros-infrastructure/rep/pull/360#discussion_r902987531).

For instructions on how to build and run this see the meta-ticket https://github.com/ros2/ros2/issues/1285.

Resolves https://github.com/ros2/ros2/issues/1285


