### PR TITLE
Add service_msgs package

### DIFF
--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -17,6 +17,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
+  <!-- actions define action services -->
+  <depend>service_msgs</depend>
+
   <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -17,9 +17,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
-  <!-- actions define action services -->
-  <depend>service_msgs</depend>
-
   <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>service_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 
   <exec_depend>rosidl_core_runtime</exec_depend>

--- a/service_msgs/CHANGELOG.rst
+++ b/service_msgs/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package action_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.4.0 (------)
+--------------
+* Add service_msgs package
+* Contributors: Brian Chen
+

--- a/service_msgs/CHANGELOG.rst
+++ b/service_msgs/CHANGELOG.rst
@@ -1,9 +1,0 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package action_msgs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-1.4.0 (------)
---------------
-* Add service_msgs package
-* Contributors: Brian Chen
-

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -15,7 +15,6 @@ find_package(builtin_interfaces REQUIRED)
 # Depend on "core" generators instead of "default" generators
 # because ROS actions depend on this package
 find_package(rosidl_core_generators REQUIRED)
-find_package(unique_identifier_msgs REQUIRED)
 
 set(msg_files
   "msg/ServiceEventInfo.msg"
@@ -23,7 +22,7 @@ set(msg_files
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  DEPENDENCIES builtin_interfaces unique_identifier_msgs
+  DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -7,11 +7,13 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)
 endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+# Depend on "core" generators instead of "default" generators
+# because ROS actions depend on this package
 find_package(rosidl_core_generators REQUIRED)
 find_package(unique_identifier_msgs REQUIRED)
 

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -30,6 +30,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_core_runtime)
 
 ament_package()

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_core_generators REQUIRED)
 find_package(unique_identifier_msgs REQUIRED)
 
 set(msg_files

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(service_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
+
+set(msg_files
+  "msg/ServiceEventInfo.msg"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES builtin_interfaces unique_identifier_msgs
+  ADD_LINTER_TESTS
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/service_msgs/QUALITY_DECLARATION.md
+++ b/service_msgs/QUALITY_DECLARATION.md
@@ -90,8 +90,7 @@ The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__
 
 `service_msgs` has the following runtime ROS dependencies, which are at **Quality Level 1**:
 * `builtin_interfaces`: [QUALITY DECLARATION](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_core_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/master/rosidl_core_runtime/QUALITY_DECLARATION.md)
-* `unique_identifier_msgs`: [QUALITY DECLARATION](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
+* `rosidl_core_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/rolling/rosidl_core_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/service_msgs/QUALITY_DECLARATION.md
+++ b/service_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,114 @@
+This document is a declaration of software quality for the `service_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `service_msgs` Quality Declaration
+
+The package `service_msgs` claims to be in the **Quality Level 1** category as long as it is used with a **Quality Level 1** middleware.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`service_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#versioning).
+
+### Version Stability [1.ii]
+
+`service_msgs` is at a stable version, i.e. `>= 1.0.0`.
+Its version can be found in its [package.xml](package.xml) and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message and service definition files located in `msg` and `srv` directories are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`service_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`service_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`service_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://docs.ros.org/en/rolling/Contributing/Developer-Guide.html#quality-practices).
+
+### Change Requests [2.i]
+
+This package requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation
+
+### Feature Documentation [3.i]
+
+`service_msgs` has a list of provided [messages and services](README.md).
+New messages and services require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`service_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `service_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There is an automated test which runs a linter that ensures each file has a license statement.
+
+The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__rcl_interfaces__ubuntu_focal_amd64/lastCompletedBuild/testReport/)
+
+### Copyright Statements [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `service_msgs`.
+
+There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+
+The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__rcl_interfaces__ubuntu_focal_amd64/lastCompletedBuild/testReport/)
+
+## Testing [4]
+
+`service_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests and has no coverage or performance requirements.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]/[5.ii]
+
+`service_msgs` has the following runtime ROS dependencies, which are at **Quality Level 1**:
+* `builtin_interfaces`: [QUALITY DECLARATION](../builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `unique_identifier_msgs`: [QUALITY DECLARATION](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Direct Runtime Non-ROS Dependencies [5.iii]
+
+`service_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`service_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/service_msgs/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/service_msgs/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/service_msgs/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/service_msgs/)
+
+## Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/service_msgs/QUALITY_DECLARATION.md
+++ b/service_msgs/QUALITY_DECLARATION.md
@@ -57,8 +57,8 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Feature Documentation [3.i]
 
-`service_msgs` has a list of provided [messages and services](README.md).
-New messages and services require their own documentation in order to be added.
+`service_msgs` has a list of provided [ROS interfaces](README.md).
+New interfaces require their own documentation in order to be added.
 
 ### Public API Documentation [3.ii]
 
@@ -90,7 +90,7 @@ The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__
 
 `service_msgs` has the following runtime ROS dependencies, which are at **Quality Level 1**:
 * `builtin_interfaces`: [QUALITY DECLARATION](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `rosidl_core_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/master/rosidl_core_runtime/QUALITY_DECLARATION.md)
 * `unique_identifier_msgs`: [QUALITY DECLARATION](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
@@ -106,7 +106,6 @@ It has several "buildtool" dependencies, which do not affect the resulting quali
 Currently nightly results can be seen here:
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/service_msgs/)
 * [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/service_msgs/)
-* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/service_msgs/)
 * [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/service_msgs/)
 
 ## Vulnerability Disclosure Policy [7.i]

--- a/service_msgs/README.md
+++ b/service_msgs/README.md
@@ -1,0 +1,13 @@
+# service_msgs
+This package contains message types useful for ros2 services.
+
+More information about services can be found on its [design article](http://design.ros2.org/articles/actions.html).
+
+For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html).
+
+## Messages (.msg)
+* [ServiceEventInfo](msg/ServiceEventInfo.msg): Service event information.
+
+
+## Quality Declaration
+This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/service_msgs/README.md
+++ b/service_msgs/README.md
@@ -1,13 +1,18 @@
 # service_msgs
-This package contains message types useful for ros2 services.
 
-More information about services can be found on its [design article](http://design.ros2.org/articles/actions.html).
+This package contains message types used by ROS services.
 
-For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html).
+For more information about ROS services, check out the following links:
+
+* [About ROS 2 interfaces](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html)
+* [Understanding services](https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.html)
 
 ## Messages (.msg)
-* [ServiceEventInfo](msg/ServiceEventInfo.msg): Service event information.
+
+* [ServiceEventInfo](msg/ServiceEventInfo.msg): Part of a service event message that contains information such as timestamp and event type.
+This is part of the Service Introspection feature of ROS 2 (see [REP 2012](https://ros.org/reps/rep-2012.html)).
 
 
 ## Quality Declaration
+
 This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/service_msgs/README.md
+++ b/service_msgs/README.md
@@ -15,4 +15,4 @@ This is part of the Service Introspection feature of ROS 2 (see [REP 2012](https
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.
+See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/service_msgs/msg/ServiceEventInfo.msg
+++ b/service_msgs/msg/ServiceEventInfo.msg
@@ -16,9 +16,3 @@ unique_identifier_msgs/UUID client_id
 # Sequence number for the request
 # Combined with the client ID, this creates a unique ID for the service transaction
 int64 sequence_number
-
-# Name of the service, i.e. add_two_ints_service
-string service_name
-
-# Name of the service event, i.e. AddTwoInts_Request
-string event_name

--- a/service_msgs/msg/ServiceEventInfo.msg
+++ b/service_msgs/msg/ServiceEventInfo.msg
@@ -1,0 +1,24 @@
+uint8 REQUEST_SENT = 0
+uint8 REQUEST_RECEIVED = 1
+uint8 RESPONSE_SENT = 2
+uint8 RESPONSE_RECEIVED = 3
+
+# The type of event this message represents
+uint8 event_type
+
+# Timestamp for when the event occurred (sent or received time)
+builtin_interfaces/Time stamp
+
+# Unique identifier for the client that sent the service request
+# Note, this is only unique for the current session
+unique_identifier_msgs/UUID client_id
+
+# Sequence number for the request
+# Combined with the client ID, this creates a unique ID for the service transaction
+int64 sequence_number
+
+# Name of the service, i.e. add_two_ints_service
+string service_name
+
+# Name of the service event, i.e. AddTwoInts_Request
+string event_name

--- a/service_msgs/msg/ServiceEventInfo.msg
+++ b/service_msgs/msg/ServiceEventInfo.msg
@@ -10,8 +10,11 @@ uint8 event_type
 builtin_interfaces/Time stamp
 
 # Unique identifier for the client that sent the service request
-# Note, this is only unique for the current session
-unique_identifier_msgs/UUID client_id
+# Note, this is only unique for the current session.
+# The size here has to match the size of rmw_dds_common/msg/Gid,
+# but unfortunately we cannot use that message directly due to a
+# circular dependency.
+char[16] client_gid
 
 # Sequence number for the request
 # Combined with the client ID, this creates a unique ID for the service transaction

--- a/service_msgs/package.xml
+++ b/service_msgs/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
-  <depend>unique_identifier_msgs</depend>
 
   <exec_depend>rosidl_core_runtime</exec_depend>
 

--- a/service_msgs/package.xml
+++ b/service_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>service_msgs</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <description>Messages definitions common among all ROS services</description>
 
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>

--- a/service_msgs/package.xml
+++ b/service_msgs/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>service_msgs</name>
+  <version>1.3.0</version>
+  <description>Messages definitions common among all ROS services</description>
+
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="brian.chen@openrobotics.org">Brian Chen</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>builtin_interfaces</depend>
+  <depend>unique_identifier_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/service_msgs/package.xml
+++ b/service_msgs/package.xml
@@ -12,12 +12,12 @@
   <author email="brian.chen@openrobotics.org">Brian Chen</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_core_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This PR is a prototype for the service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) adding a `service_msgs` package implementing the proposed embedded message approach (https://github.com/ros-infrastructure/rep/pull/360#discussion_r902987531).

For instructions on how to build and run this see the meta-ticket https://github.com/ros2/ros2/issues/1285.




