### PR TITLE
Depend on rosidl_core_generators for packages required by actions

### DIFF
--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -38,6 +38,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_core_runtime)
 
 ament_package()

--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -12,7 +12,9 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
+# Depend on "core" generators instead of "default" generators
+# because ROS actions depend on this package
+find_package(rosidl_core_generators REQUIRED)
 find_package(unique_identifier_msgs REQUIRED)
 
 set(msg_files

--- a/action_msgs/QUALITY_DECLARATION.md
+++ b/action_msgs/QUALITY_DECLARATION.md
@@ -90,7 +90,7 @@ The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__
 
 `action_msgs` has the following runtime ROS dependencies, which are at **Quality Level 1**:
 * `builtin_interfaces`: [QUALITY DECLARATION](../builtin_interfaces/QUALITY_DECLARATION.md)
-* `rosidl_default_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `rosidl_core_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/master/rosidl_core_runtime/QUALITY_DECLARATION.md)
 * `unique_identifier_msgs`: [QUALITY DECLARATION](https://github.com/ros2/unique_identifier_msgs/tree/master/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -19,7 +19,7 @@
   <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_core_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/action_msgs/package.xml
+++ b/action_msgs/package.xml
@@ -14,7 +14,7 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>

--- a/builtin_interfaces/CMakeLists.txt
+++ b/builtin_interfaces/CMakeLists.txt
@@ -21,6 +21,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_core_runtime)
 
 ament_package()

--- a/builtin_interfaces/CMakeLists.txt
+++ b/builtin_interfaces/CMakeLists.txt
@@ -11,7 +11,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
+# Depend on "core" generators instead of "default" generators
+# because ROS actions depend on this package
+find_package(rosidl_core_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Duration.msg"

--- a/builtin_interfaces/QUALITY_DECLARATION.md
+++ b/builtin_interfaces/QUALITY_DECLARATION.md
@@ -89,7 +89,7 @@ The nightly test can be found at [here](http://build.ros2.org/view/Rpr/job/Rpr__
 ### Direct Runtime ROS Dependencies [5.i]/[5.ii]
 
 `builtin_interfaces` has the following ROS dependencies, which are at **Quality Level 1**:
-* `rosidl_default_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+* `rosidl_core_runtime`: [QUALITY DECLARATION](https://github.com/ros2/rosidl_core/tree/master/rosidl_core_runtime/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
 

--- a/builtin_interfaces/package.xml
+++ b/builtin_interfaces/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_core_runtime</exec_depend>
 
   <test_depend>ament_lint_common</test_depend>
 

--- a/builtin_interfaces/package.xml
+++ b/builtin_interfaces/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>rosidl_core_generators</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -19,7 +19,6 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>test_interface_files</build_depend>
 
-  <depend>action_msgs</depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
This allows us to forward a dependency on action_msgs for users and avoid a dependency cycle.

Connected to https://github.com/ros2/rosidl_defaults/pull/22