### PR TITLE
lifecycle_msgs: remove non-ASCII chars from field comments

### DIFF
--- a/lifecycle_msgs/msg/State.msg
+++ b/lifecycle_msgs/msg/State.msg
@@ -14,7 +14,7 @@ uint8 PRIMARY_STATE_UNCONFIGURED = 1
 # This state represents a node that is not currently performing any processing.
 uint8 PRIMARY_STATE_INACTIVE = 2
 
-# This is the main state of the node’s life cycle. While in this state, the node
+# This is the main state of the node's life cycle. While in this state, the node
 # performs any processing, responds to service requests, reads and processes
 # data, produces output, etc.
 uint8 PRIMARY_STATE_ACTIVE = 3
@@ -26,11 +26,11 @@ uint8 PRIMARY_STATE_FINALIZED = 4
 # Temporary intermediate states. When a transition is requested, the node
 # changes its state into one of these states.
 
-# In this transition state the node’s onConfigure callback will be called to
+# In this transition state the node's onConfigure callback will be called to
 # allow the node to load its configuration and conduct any required setup.
 uint8 TRANSITION_STATE_CONFIGURING = 10
 
-# In this transition state the node’s callback onCleanup will be called to clear
+# In this transition state the node's callback onCleanup will be called to clear
 # all state and return the node to a functionally equivalent state as when
 # first created.
 uint8 TRANSITION_STATE_CLEANINGUP = 11

--- a/lifecycle_msgs/msg/Transition.msg
+++ b/lifecycle_msgs/msg/Transition.msg
@@ -9,11 +9,11 @@
 # the constructor.
 uint8 TRANSITION_CREATE = 0
 
-# The node’s onConfigure callback will be called to allow the node to load its
+# The node's onConfigure callback will be called to allow the node to load its
 # configuration and conduct any required setup.
 uint8 TRANSITION_CONFIGURE = 1
 
-# The node’s callback onCleanup will be called in this transition to allow the
+# The node's callback onCleanup will be called in this transition to allow the
 # node to load its configuration and conduct any required setup.
 uint8 TRANSITION_CLEANUP = 2
 


### PR DESCRIPTION
As per subject.

I'm working on an old platform with an ancient version of GCC which isn't capable of processing files with non-ASCII chars in them.

The unicode apostrophes caused build failures, so 48d66fbb removes them.
