### PR TITLE
Update common_interfaces to C++17. (#215)

### DIFF
--- a/action_msgs/CMakeLists.txt
+++ b/action_msgs/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(action_msgs)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/builtin_interfaces/CMakeLists.txt
+++ b/builtin_interfaces/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(builtin_interfaces)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/composition_interfaces/CMakeLists.txt
+++ b/composition_interfaces/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(composition_interfaces)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/lifecycle_msgs/CMakeLists.txt
+++ b/lifecycle_msgs/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(lifecycle_msgs)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rcl_interfaces)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/rosgraph_msgs/CMakeLists.txt
+++ b/rosgraph_msgs/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosgraph_msgs)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/service_msgs/CMakeLists.txt
+++ b/service_msgs/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(service_msgs)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wpedantic -Wnon-virtual-dtor -Woverloaded-virtual)

--- a/statistics_msgs/CMakeLists.txt
+++ b/statistics_msgs/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 
 project(statistics_msgs)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -7,9 +7,10 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
 endif()
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)


### PR DESCRIPTION
The main reason to do this is so that we can compile common_interfaces with the clang static analyzer. As of clang++-14 (what is in Ubuntu 22.04), the default still seems to be C++14, so we need to specify C++17 so that new things in the rclcpp headers work properly.

Further, due to reasons I don't fully understand, I needed to set CMAKE_CXX_STANDARD_REQUIRED in order for clang to really use that version. So set this as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>