### PR TITLE
Add GetTypeDescription.srv (rep2011)

### DIFF
--- a/type_description_interfaces/CMakeLists.txt
+++ b/type_description_interfaces/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(type_description_interfaces)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/type_description_interfaces/CMakeLists.txt
+++ b/type_description_interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FieldType.msg"
   "msg/IndividualTypeDescription.msg"
   "msg/TypeDescription.msg"
+  "srv/GetTypeDescription.srv"
   ADD_LINTER_TESTS
 )
 

--- a/type_description_interfaces/CMakeLists.txt
+++ b/type_description_interfaces/CMakeLists.txt
@@ -21,6 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/IndividualTypeDescription.msg"
   "msg/KeyValue.msg"
   "msg/TypeDescription.msg"
+  "msg/TypeSource.msg"
   "srv/GetTypeDescription.srv"
   ADD_LINTER_TESTS
 )

--- a/type_description_interfaces/CMakeLists.txt
+++ b/type_description_interfaces/CMakeLists.txt
@@ -19,6 +19,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Field.msg"
   "msg/FieldType.msg"
   "msg/IndividualTypeDescription.msg"
+  "msg/KeyValue.msg"
   "msg/TypeDescription.msg"
   "srv/GetTypeDescription.srv"
   ADD_LINTER_TESTS

--- a/type_description_interfaces/msg/KeyValue.msg
+++ b/type_description_interfaces/msg/KeyValue.msg
@@ -1,0 +1,2 @@
+string key
+string value

--- a/type_description_interfaces/msg/KeyValue.msg
+++ b/type_description_interfaces/msg/KeyValue.msg
@@ -1,2 +1,4 @@
+# Represents an arbitrary key-value pair for application-specific information.
+
 string key
 string value

--- a/type_description_interfaces/msg/TypeSource.msg
+++ b/type_description_interfaces/msg/TypeSource.msg
@@ -4,9 +4,13 @@
 string type_name
 
 # The type of the original source file, typically matching the file extension.
-# Well-known encodings: "idl", "msg", "srv", "action", "dynamic".
+# Well-known encodings: "idl", "msg", "srv", "action", "dynamic", "implicit".
+# "dynamic" specifies a type created programmatically by a user, thus having no source.
+# "implicit" specifies a type created automatically as a subtype of a
+# complex type (service or action) - such as the request message for a service.
+# Implicit types will have no contents, the full source will be available on the parent srv/action.
 string encoding
 
 # Dumped contents of the interface definition source file.
-# If this was a type created programmatically (encoding "dynamic"), this field will be empty.
+# If `encoding` is "dynamic" or "implicit", this field will be empty.
 string raw_file_contents

--- a/type_description_interfaces/msg/TypeSource.msg
+++ b/type_description_interfaces/msg/TypeSource.msg
@@ -1,0 +1,16 @@
+# Represents the original source of a ROS 2 interface definition.
+
+uint8 ENCODING_NOT_SET = 0
+uint8 ENCODING_MSG = 1
+uint8 ENCODING_SRV = 2
+uint8 ENCODING_ACTION = 3
+uint8 ENCODING_IDL = 4
+
+# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format
+string type_name
+
+# The type of the original source file, from the above constants
+uint8 encoding
+
+# Dumped contents of the interface definition source file
+string raw_file_contents

--- a/type_description_interfaces/msg/TypeSource.msg
+++ b/type_description_interfaces/msg/TypeSource.msg
@@ -1,16 +1,12 @@
 # Represents the original source of a ROS 2 interface definition.
 
-uint8 ENCODING_NOT_SET = 0
-uint8 ENCODING_MSG = 1
-uint8 ENCODING_SRV = 2
-uint8 ENCODING_ACTION = 3
-uint8 ENCODING_IDL = 4
-
-# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format
+# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format.
 string type_name
 
-# The type of the original source file, from the above constants
-uint8 encoding
+# The type of the original source file, typically matching the file extension.
+# Well-known encodings: "idl", "msg", "srv", "action", "dynamic".
+string encoding
 
-# Dumped contents of the interface definition source file
+# Dumped contents of the interface definition source file.
+# If this was a type created programmatically (encoding "dynamic"), this field will be empty.
 string raw_file_contents

--- a/type_description_interfaces/package.xml
+++ b/type_description_interfaces/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
+  <depend>service_msgs</depend>
 
   <exec_depend>rosidl_core_runtime</exec_depend>
 

--- a/type_description_interfaces/package.xml
+++ b/type_description_interfaces/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_depend>rosidl_core_generators</buildtool_depend>
+
   <depend>service_msgs</depend>
 
   <exec_depend>rosidl_core_runtime</exec_depend>

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -17,7 +17,10 @@ string failure_reason
 # The parsed type description which can be used programmatically.
 TypeDescription type_description
 
-# List of sources, including all comments and whitespace.
+# A list containing the interface definition source text of the requested type,
+# plus all types it recursively depends on.
+# Each source text is a copy of the original contents of the
+# .msg, .srv, .action, .idl, or other file if it exists, including comments and whitespace.
 # Sources can be matched with IndividualTypeDescriptions by their `type_name`.
 # The `encoding` field of each entry informs how to interpret its contents.
 TypeSource[] type_sources

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -1,4 +1,7 @@
+# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format
 string type_name
+
+# REP-2011 RIHS hash string, which looks like RIHSxx_hashvalue
 string type_version_hash
 ---
 # True if the type description information is available and populated in the response
@@ -8,9 +11,14 @@ string failure_reason
 
 # The idl or msg file name
 string type_description_raw_file_name
+
 # The idl or msg file, with comments and whitespace
 # The file extension and/or the contents can be used to determine the format
+# This contains all recursive raw files, each separated by a line of 80 '=' characters
+# The order will be the same as the TypeDescription -
+# which is top level interface then referenced type descriptions in alphabetical order by type_name
 string type_description_raw
+
 # The parsed type description which can be used programmatically
 TypeDescription type_description
 

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -2,7 +2,7 @@
 string type_name
 
 # REP-2011 RIHS hash string, which looks like RIHSxx_hashvalue
-string type_version_hash
+string type_hash
 
 # Whether to return the original idl or msg file(s) in the response, if available
 bool include_type_sources true

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -4,37 +4,30 @@ string type_name
 # REP-2011 RIHS hash string, which looks like RIHSxx_hashvalue
 string type_version_hash
 
-# Whether to return the raw idl or msg file(s) in the response, if available
-bool include_raw_description true
+# Whether to return the original idl or msg file(s) in the response, if available
+bool include_type_sources true
 ---
-# include_raw_description requested, and provided successfully
-uint8 RAW_DESCRIPTION_REQUESTED_PROVIDED = 0
-# include_raw_description disabled, so type_description_raw was left empty
-uint8 RAW_DESCRIPTION_NOT_REQUESTED_NOT_PROVIDED = 1
-# include_raw_description requested, but no raw version available (perhaps for dynamically created types)
-uint8 RAW_DESCRIPTION_REQUESTED_NOT_AVAILABLE = 2
+# sources requested, and provided successfully
+uint8 SOURCES_REQUESTED_PROVIDED = 0
+# sources disabled, so type_sources was left empty
+uint8 SOURCES_NOT_REQUESTED_NOT_PROVIDED = 1
+# sources requested, but no source available (perhaps for dynamically created types)
+uint8 SOURCES_REQUESTED_NOT_AVAILABLE = 2
 
 # True if the type description information is available and populated in the response
 # If false, all other fields except `reason` are considered undefined
 bool successful
 # If `successful` is false, contains a reason for failure.
-# On success, may contain a reason for missing type_description_raw.
+# On success, may contain a reason for missing sources.
 string reason
 
-# Contains a value from RAW_DESCRIPTION_ constants, explaining whether the
-# `type_description_raw_file_name` and `type_description_raw` fields contain valid data.
-uint8 type_description_raw_result
+# Contains a value from above constants, explaining whether the
+# `type_sources` fields contain valid data.
+uint8 type_sources_result
 
-# The idl or msg file name
-# Empty if not available, which will be noted in `reason`
-string type_description_raw_file_name
-
-# The idl or msg file, with comments and whitespace
-# The file extension and/or the contents can be used to determine the format
-# This contains all recursive raw files, each separated by a line of 80 '=' characters
-# The order will be the same as the TypeDescription -
-# which is top level interface, then referenced type descriptions in alphabetical order by type_name
-string type_description_raw
+# List of idl or msg/srv/action source files, including all comments and whitespace.
+# Sources can be matched with IndividualTypeDescriptions by their type_name
+TypeSource[] type_sources
 
 # The parsed type description which can be used programmatically
 TypeDescription type_description

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -11,17 +11,18 @@ bool include_raw_description true
 uint8 RAW_DESCRIPTION_REQUESTED_PROVIDED = 0
 # include_raw_description disabled, so type_description_raw was left empty
 uint8 RAW_DESCRIPTION_NOT_REQUESTED_NOT_PROVIDED = 1
-# include_raw_description requested, but no raw version available (perhaps for )
+# include_raw_description requested, but no raw version available (perhaps for dynamically created types)
 uint8 RAW_DESCRIPTION_REQUESTED_NOT_AVAILABLE = 2
 
 # True if the type description information is available and populated in the response
+# If false, all other fields except `reason` are considered undefined
 bool successful
 # If `successful` is false, contains a reason for failure.
 # On success, may contain a reason for missing type_description_raw.
 string reason
 
-# Contains a value from RAW_DESCRIPTION_ constants,
-# explaining the value of `type_description_raw_file_name` and  `type_description_raw`
+# Contains a value from RAW_DESCRIPTION_ constants, explaining whether the
+# `type_description_raw_file_name` and `type_description_raw` fields contain valid data.
 uint8 type_description_raw_result
 
 # The idl or msg file name

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -3,25 +3,40 @@ string type_name
 
 # REP-2011 RIHS hash string, which looks like RIHSxx_hashvalue
 string type_version_hash
+
+# Whether to return the raw idl or msg file(s) in the response, if available
+bool include_raw_description true
 ---
+# include_raw_description requested, and provided successfully
+uint8 RAW_DESCRIPTION_REQUESTED_PROVIDED = 0
+# include_raw_description disabled, so type_description_raw was left empty
+uint8 RAW_DESCRIPTION_NOT_REQUESTED_NOT_PROVIDED = 1
+# include_raw_description requested, but no raw version available (perhaps for )
+uint8 RAW_DESCRIPTION_REQUESTED_NOT_AVAILABLE = 2
+
 # True if the type description information is available and populated in the response
 bool successful
-# Empty if 'successful' was true, otherwise contains details on why it failed
-string failure_reason
+# If `successful` is false, contains a reason for failure.
+# On success, may contain a reason for missing type_description_raw.
+string reason
+
+# Contains a value from RAW_DESCRIPTION_ constants,
+# explaining the value of `type_description_raw_file_name` and  `type_description_raw`
+uint8 type_description_raw_result
 
 # The idl or msg file name
+# Empty if not available, which will be noted in `reason`
 string type_description_raw_file_name
 
 # The idl or msg file, with comments and whitespace
 # The file extension and/or the contents can be used to determine the format
 # This contains all recursive raw files, each separated by a line of 80 '=' characters
 # The order will be the same as the TypeDescription -
-# which is top level interface then referenced type descriptions in alphabetical order by type_name
+# which is top level interface, then referenced type descriptions in alphabetical order by type_name
 string type_description_raw
 
 # The parsed type description which can be used programmatically
 TypeDescription type_description
 
 # Key-value pairs of extra information.
-string[] extra_information_keys
-string[] extra_information_values
+KeyValue[] extra_information

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -1,0 +1,19 @@
+string type_name
+string type_version_hash
+---
+# True if the type description information is available and populated in the response
+bool successful
+# Empty if 'successful' was true, otherwise contains details on why it failed
+string failure_reason
+
+# The idl or msg file name
+string type_description_raw_file_name
+# The idl or msg file, with comments and whitespace
+# The file extension and/or the contents can be used to determine the format
+string type_description_raw
+# The parsed type description which can be used programmatically
+TypeDescription type_description
+
+# Key-value pairs of extra information.
+string[] extra_information_keys
+string[] extra_information_values

--- a/type_description_interfaces/srv/GetTypeDescription.srv
+++ b/type_description_interfaces/srv/GetTypeDescription.srv
@@ -1,36 +1,26 @@
-# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format
+# ROS interface type name, in PACKAGE/NAMESPACE/TYPENAME format.
 string type_name
 
-# REP-2011 RIHS hash string, which looks like RIHSxx_hashvalue
+# REP-2011 RIHS hash string.
 string type_hash
 
-# Whether to return the original idl or msg file(s) in the response, if available
+# Whether to return the original idl/msg/etc. source file(s) in the response.
 bool include_type_sources true
 ---
-# sources requested, and provided successfully
-uint8 SOURCES_REQUESTED_PROVIDED = 0
-# sources disabled, so type_sources was left empty
-uint8 SOURCES_NOT_REQUESTED_NOT_PROVIDED = 1
-# sources requested, but no source available (perhaps for dynamically created types)
-uint8 SOURCES_REQUESTED_NOT_AVAILABLE = 2
-
-# True if the type description information is available and populated in the response
-# If false, all other fields except `reason` are considered undefined
+# True if the type description information is available and populated in the response.
+# If false, all other fields except `failure_reason` are considered undefined.
 bool successful
 # If `successful` is false, contains a reason for failure.
-# On success, may contain a reason for missing sources.
-string reason
+# If `successful` is true, this is left empty.
+string failure_reason
 
-# Contains a value from above constants, explaining whether the
-# `type_sources` fields contain valid data.
-uint8 type_sources_result
-
-# List of idl or msg/srv/action source files, including all comments and whitespace.
-# Sources can be matched with IndividualTypeDescriptions by their type_name
-TypeSource[] type_sources
-
-# The parsed type description which can be used programmatically
+# The parsed type description which can be used programmatically.
 TypeDescription type_description
+
+# List of sources, including all comments and whitespace.
+# Sources can be matched with IndividualTypeDescriptions by their `type_name`.
+# The `encoding` field of each entry informs how to interpret its contents.
+TypeSource[] type_sources
 
 # Key-value pairs of extra information.
 KeyValue[] extra_information


### PR DESCRIPTION
Part of https://github.com/ros2/ros2/issues/1159

Adds service interface for retrieving type descriptions from nodes