### PR TITLE
Runtime Interface Reflection: type_description_interfaces_utils

### DIFF
--- a/type_description_interfaces_static/CMakeLists.txt
+++ b/type_description_interfaces_static/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(type_description_interfaces_static)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_runtime_c REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+
+file(GLOB sources "src/*.c")
+
+add_library(${PROJECT_NAME} ${sources})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rosidl_runtime_c::rosidl_runtime_c
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+)
+
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-export
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+ament_export_targets(${PROJECT_NAME}-export HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ament_cmake_ros
+  rosidl_runtime_c
+  rosidl_runtime_cpp
+)
+
+ament_package()

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__builder.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__builder.hpp
@@ -1,0 +1,88 @@
+// generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__BUILDER_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__BUILDER_HPP_
+
+#include <algorithm>
+#include <utility>
+
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace builder
+{
+
+class Init_Field_default_value
+{
+public:
+  explicit Init_Field_default_value(::type_description_interfaces::msg::Field & msg)
+  : msg_(msg)
+  {}
+  ::type_description_interfaces::msg::Field default_value(::type_description_interfaces::msg::Field::_default_value_type arg)
+  {
+    msg_.default_value = std::move(arg);
+    return std::move(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::Field msg_;
+};
+
+class Init_Field_type
+{
+public:
+  explicit Init_Field_type(::type_description_interfaces::msg::Field & msg)
+  : msg_(msg)
+  {}
+  Init_Field_default_value type(::type_description_interfaces::msg::Field::_type_type arg)
+  {
+    msg_.type = std::move(arg);
+    return Init_Field_default_value(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::Field msg_;
+};
+
+class Init_Field_name
+{
+public:
+  Init_Field_name()
+  : msg_(::rosidl_runtime_cpp::MessageInitialization::SKIP)
+  {}
+  Init_Field_type name(::type_description_interfaces::msg::Field::_name_type arg)
+  {
+    msg_.name = std::move(arg);
+    return Init_Field_type(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::Field msg_;
+};
+
+}  // namespace builder
+
+}  // namespace msg
+
+template<typename MessageType>
+auto build();
+
+template<>
+inline
+auto build<::type_description_interfaces::msg::Field>()
+{
+  return type_description_interfaces::msg::builder::Init_Field_name();
+}
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__BUILDER_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__functions.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__functions.c
@@ -1,0 +1,292 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/field__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `name`
+// Member `default_value`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `type`
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+
+bool
+type_description_interfaces__msg__Field__init(type_description_interfaces__msg__Field * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__init(&msg->name)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__init(&msg->type)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__init(&msg->default_value)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__Field__fini(type_description_interfaces__msg__Field * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // name
+  rosidl_runtime_c__String__fini(&msg->name);
+  // type
+  type_description_interfaces__msg__FieldType__fini(&msg->type);
+  // default_value
+  rosidl_runtime_c__String__fini(&msg->default_value);
+}
+
+bool
+type_description_interfaces__msg__Field__are_equal(const type_description_interfaces__msg__Field * lhs, const type_description_interfaces__msg__Field * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->name), &(rhs->name)))
+  {
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__are_equal(
+      &(lhs->type), &(rhs->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->default_value), &(rhs->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__Field__copy(
+  const type_description_interfaces__msg__Field * input,
+  type_description_interfaces__msg__Field * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->name), &(output->name)))
+  {
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__copy(
+      &(input->type), &(output->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__copy(
+      &(input->default_value), &(output->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__Field *
+type_description_interfaces__msg__Field__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field * msg = (type_description_interfaces__msg__Field *)allocator.allocate(sizeof(type_description_interfaces__msg__Field), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__Field));
+  bool success = type_description_interfaces__msg__Field__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__Field__destroy(type_description_interfaces__msg__Field * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__Field__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__Field__Sequence__init(type_description_interfaces__msg__Field__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__Field *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__Field), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__Field__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__Field__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__Field__Sequence__fini(type_description_interfaces__msg__Field__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__Field__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__Field__Sequence *
+type_description_interfaces__msg__Field__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field__Sequence * array = (type_description_interfaces__msg__Field__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__Field__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__Field__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__Field__Sequence__destroy(type_description_interfaces__msg__Field__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__Field__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__Field__Sequence__are_equal(const type_description_interfaces__msg__Field__Sequence * lhs, const type_description_interfaces__msg__Field__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__Field__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__Field__Sequence__copy(
+  const type_description_interfaces__msg__Field__Sequence * input,
+  type_description_interfaces__msg__Field__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__Field);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__Field * data =
+      (type_description_interfaces__msg__Field *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__Field__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__Field__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__Field__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__functions.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__functions.h
@@ -1,0 +1,177 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__FUNCTIONS_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "type_description_interfaces/msg/detail/field__struct.h"
+
+/// Initialize msg/Field message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * type_description_interfaces__msg__Field
+ * )) before or use
+ * type_description_interfaces__msg__Field__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__init(type_description_interfaces__msg__Field * msg);
+
+/// Finalize msg/Field message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__Field__fini(type_description_interfaces__msg__Field * msg);
+
+/// Create msg/Field message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * type_description_interfaces__msg__Field__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__Field *
+type_description_interfaces__msg__Field__create();
+
+/// Destroy msg/Field message.
+/**
+ * It calls
+ * type_description_interfaces__msg__Field__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__Field__destroy(type_description_interfaces__msg__Field * msg);
+
+/// Check for msg/Field message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__are_equal(const type_description_interfaces__msg__Field * lhs, const type_description_interfaces__msg__Field * rhs);
+
+/// Copy a msg/Field message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__copy(
+  const type_description_interfaces__msg__Field * input,
+  type_description_interfaces__msg__Field * output);
+
+/// Initialize array of msg/Field messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * type_description_interfaces__msg__Field__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__Sequence__init(type_description_interfaces__msg__Field__Sequence * array, size_t size);
+
+/// Finalize array of msg/Field messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__Field__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__Field__Sequence__fini(type_description_interfaces__msg__Field__Sequence * array);
+
+/// Create array of msg/Field messages.
+/**
+ * It allocates the memory for the array and calls
+ * type_description_interfaces__msg__Field__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__Field__Sequence *
+type_description_interfaces__msg__Field__Sequence__create(size_t size);
+
+/// Destroy array of msg/Field messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__Field__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__Field__Sequence__destroy(type_description_interfaces__msg__Field__Sequence * array);
+
+/// Check for msg/Field message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__Sequence__are_equal(const type_description_interfaces__msg__Field__Sequence * lhs, const type_description_interfaces__msg__Field__Sequence * rhs);
+
+/// Copy an array of msg/Field messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__Field__Sequence__copy(
+  const type_description_interfaces__msg__Field__Sequence * input,
+  type_description_interfaces__msg__Field__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__FUNCTIONS_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_fastrtps_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_fastrtps_c.h
@@ -1,0 +1,37 @@
+// generated from rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+
+
+#include <stddef.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t get_serialized_size_type_description_interfaces__msg__Field(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t max_serialized_size_type_description_interfaces__msg__Field(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, type_description_interfaces, msg, Field)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_fastrtps_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_fastrtps_cpp.hpp
@@ -1,0 +1,80 @@
+// generated from rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h"
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
+#endif
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+#include "fastcdr/Cdr.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace typesupport_fastrtps_cpp
+{
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_serialize(
+  const type_description_interfaces::msg::Field & ros_message,
+  eprosima::fastcdr::Cdr & cdr);
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  type_description_interfaces::msg::Field & ros_message);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+get_serialized_size(
+  const type_description_interfaces::msg::Field & ros_message,
+  size_t current_alignment);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+max_serialized_size_Field(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+}  // namespace typesupport_fastrtps_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, type_description_interfaces, msg, Field)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_c.h
@@ -1,0 +1,26 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, Field)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_cpp.hpp
@@ -1,0 +1,27 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// TODO(dirk-thomas) these visibility macros should be message package specific
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, Field)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__struct.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__struct.h
@@ -1,0 +1,56 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'name'
+// Member 'default_value'
+#include "rosidl_runtime_c/string.h"
+// Member 'type'
+#include "type_description_interfaces/msg/detail/field_type__struct.h"
+
+/// Struct defined in msg/Field in the package type_description_interfaces.
+/**
+  * Represents a single field in a type.
+ */
+typedef struct type_description_interfaces__msg__Field
+{
+  /// Name of the field.
+  rosidl_runtime_c__String name;
+  /// Type of the field, including details about the type like length, nested name, etc.
+  type_description_interfaces__msg__FieldType type;
+  /// Literal default value of the field as a string, as it appeared in the original
+  /// message description file, whether that be .msg/.srv/.action or .idl.
+  rosidl_runtime_c__String default_value;
+} type_description_interfaces__msg__Field;
+
+// Struct for a sequence of type_description_interfaces__msg__Field.
+typedef struct type_description_interfaces__msg__Field__Sequence
+{
+  type_description_interfaces__msg__Field * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} type_description_interfaces__msg__Field__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__struct.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__struct.hpp
@@ -1,0 +1,164 @@
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'type'
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__type_description_interfaces__msg__Field __attribute__((deprecated))
+#else
+# define DEPRECATED__type_description_interfaces__msg__Field __declspec(deprecated)
+#endif
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+// message struct
+template<class ContainerAllocator>
+struct Field_
+{
+  using Type = Field_<ContainerAllocator>;
+
+  explicit Field_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type(_init)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->name = "";
+      this->default_value = "";
+    }
+  }
+
+  explicit Field_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : name(_alloc),
+    type(_alloc, _init),
+    default_value(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->name = "";
+      this->default_value = "";
+    }
+  }
+
+  // field types and members
+  using _name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _name_type name;
+  using _type_type =
+    type_description_interfaces::msg::FieldType_<ContainerAllocator>;
+  _type_type type;
+  using _default_value_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _default_value_type default_value;
+
+  // setters for named parameter idiom
+  Type & set__name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->name = _arg;
+    return *this;
+  }
+  Type & set__type(
+    const type_description_interfaces::msg::FieldType_<ContainerAllocator> & _arg)
+  {
+    this->type = _arg;
+    return *this;
+  }
+  Type & set__default_value(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->default_value = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    type_description_interfaces::msg::Field_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const type_description_interfaces::msg::Field_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::Field_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::Field_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::Field_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::Field_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::Field_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::Field_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::Field_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::Field_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__type_description_interfaces__msg__Field
+    std::shared_ptr<type_description_interfaces::msg::Field_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__type_description_interfaces__msg__Field
+    std::shared_ptr<type_description_interfaces::msg::Field_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const Field_ & other) const
+  {
+    if (this->name != other.name) {
+      return false;
+    }
+    if (this->type != other.type) {
+      return false;
+    }
+    if (this->default_value != other.default_value) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const Field_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct Field_
+
+// alias to use template instance with default allocator
+using Field =
+  type_description_interfaces::msg::Field_<std::allocator<void>>;
+
+// constant definitions
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__STRUCT_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__traits.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__traits.hpp
@@ -1,0 +1,146 @@
+// generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TRAITS_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TRAITS_HPP_
+
+#include <stdint.h>
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+#include "rosidl_runtime_cpp/traits.hpp"
+
+// Include directives for member types
+// Member 'type'
+#include "type_description_interfaces/msg/detail/field_type__traits.hpp"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+inline void to_flow_style_yaml(
+  const Field & msg,
+  std::ostream & out)
+{
+  out << "{";
+  // member: name
+  {
+    out << "name: ";
+    rosidl_generator_traits::value_to_yaml(msg.name, out);
+    out << ", ";
+  }
+
+  // member: type
+  {
+    out << "type: ";
+    to_flow_style_yaml(msg.type, out);
+    out << ", ";
+  }
+
+  // member: default_value
+  {
+    out << "default_value: ";
+    rosidl_generator_traits::value_to_yaml(msg.default_value, out);
+  }
+  out << "}";
+}  // NOLINT(readability/fn_size)
+
+inline void to_block_style_yaml(
+  const Field & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  // member: name
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "name: ";
+    rosidl_generator_traits::value_to_yaml(msg.name, out);
+    out << "\n";
+  }
+
+  // member: type
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "type:\n";
+    to_block_style_yaml(msg.type, out, indentation + 2);
+  }
+
+  // member: default_value
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "default_value: ";
+    rosidl_generator_traits::value_to_yaml(msg.default_value, out);
+    out << "\n";
+  }
+}  // NOLINT(readability/fn_size)
+
+inline std::string to_yaml(const Field & msg, bool use_flow_style = false)
+{
+  std::ostringstream out;
+  if (use_flow_style) {
+    to_flow_style_yaml(msg, out);
+  } else {
+    to_block_style_yaml(msg, out);
+  }
+  return out.str();
+}
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+namespace rosidl_generator_traits
+{
+
+[[deprecated("use type_description_interfaces::msg::to_block_style_yaml() instead")]]
+inline void to_yaml(
+  const type_description_interfaces::msg::Field & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  type_description_interfaces::msg::to_block_style_yaml(msg, out, indentation);
+}
+
+[[deprecated("use type_description_interfaces::msg::to_yaml() instead")]]
+inline std::string to_yaml(const type_description_interfaces::msg::Field & msg)
+{
+  return type_description_interfaces::msg::to_yaml(msg);
+}
+
+template<>
+inline const char * data_type<type_description_interfaces::msg::Field>()
+{
+  return "type_description_interfaces::msg::Field";
+}
+
+template<>
+inline const char * name<type_description_interfaces::msg::Field>()
+{
+  return "type_description_interfaces/msg/Field";
+}
+
+template<>
+struct has_fixed_size<type_description_interfaces::msg::Field>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct has_bounded_size<type_description_interfaces::msg::Field>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct is_message<type_description_interfaces::msg::Field>
+  : std::true_type {};
+
+}  // namespace rosidl_generator_traits
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TRAITS_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.c
@@ -1,0 +1,128 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#include <stddef.h>
+#include "type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_c.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "type_description_interfaces/msg/detail/field__functions.h"
+#include "type_description_interfaces/msg/detail/field__struct.h"
+
+
+// Include directives for member types
+// Member `name`
+// Member `default_value`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `type`
+#include "type_description_interfaces/msg/field_type.h"
+// Member `type`
+#include "type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_c.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_init_function(
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
+{
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
+  type_description_interfaces__msg__Field__init(message_memory);
+}
+
+void type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_fini_function(void * message_memory)
+{
+  type_description_interfaces__msg__Field__fini(message_memory);
+}
+
+static rosidl_typesupport_introspection_c__MessageMember type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_member_array[3] = {
+  {
+    "name",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_STRING,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__Field, name),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "type",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message (initialized later)
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__Field, type),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "default_value",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_STRING,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__Field, default_value),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  }
+};
+
+static const rosidl_typesupport_introspection_c__MessageMembers type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_members = {
+  "type_description_interfaces__msg",  // message namespace
+  "Field",  // message name
+  3,  // number of fields
+  sizeof(type_description_interfaces__msg__Field),
+  type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_member_array,  // message members
+  type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_init_function,  // function to initialize message memory (memory has to be allocated)
+  type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_fini_function  // function to terminate message instance (will not free memory)
+};
+
+// this is not const since it must be initialized on first access
+// since C does not allow non-integral compile-time constants
+static rosidl_message_type_support_t type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_type_support_handle = {
+  0,
+  &type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_members,
+  get_message_typesupport_handle_function,
+};
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, Field)() {
+  type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_member_array[1].members_ =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, FieldType)();
+  if (!type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_type_support_handle.typesupport_identifier) {
+    type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  return &type_description_interfaces__msg__Field__rosidl_typesupport_introspection_c__Field_message_type_support_handle;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.cpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.cpp
@@ -1,0 +1,143 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__type_support.cpp.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#include "array"
+#include "cstddef"
+#include "string"
+#include "vector"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+void Field_init_function(
+  void * message_memory, rosidl_runtime_cpp::MessageInitialization _init)
+{
+  new (message_memory) type_description_interfaces::msg::Field(_init);
+}
+
+void Field_fini_function(void * message_memory)
+{
+  auto typed_message = static_cast<type_description_interfaces::msg::Field *>(message_memory);
+  typed_message->~Field();
+}
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMember Field_message_member_array[3] = {
+  {
+    "name",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING,  // type
+    0,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::Field, name),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "type",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<type_description_interfaces::msg::FieldType>(),  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::Field, type),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "default_value",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING,  // type
+    0,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::Field, default_value),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  }
+};
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMembers Field_message_members = {
+  "type_description_interfaces::msg",  // message namespace
+  "Field",  // message name
+  3,  // number of fields
+  sizeof(type_description_interfaces::msg::Field),
+  Field_message_member_array,  // message members
+  Field_init_function,  // function to initialize message memory (memory has to be allocated)
+  Field_fini_function  // function to terminate message instance (will not free memory)
+};
+
+static const rosidl_message_type_support_t Field_message_type_support_handle = {
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
+  &Field_message_members,
+  get_message_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+get_message_type_support_handle<type_description_interfaces::msg::Field>()
+{
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::Field_message_type_support_handle;
+}
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, Field)() {
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::Field_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TYPE_SUPPORT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  type_description_interfaces,
+  msg,
+  Field
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD__TYPE_SUPPORT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__builder.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__builder.hpp
@@ -1,0 +1,104 @@
+// generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__BUILDER_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__BUILDER_HPP_
+
+#include <algorithm>
+#include <utility>
+
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace builder
+{
+
+class Init_FieldType_nested_type_name
+{
+public:
+  explicit Init_FieldType_nested_type_name(::type_description_interfaces::msg::FieldType & msg)
+  : msg_(msg)
+  {}
+  ::type_description_interfaces::msg::FieldType nested_type_name(::type_description_interfaces::msg::FieldType::_nested_type_name_type arg)
+  {
+    msg_.nested_type_name = std::move(arg);
+    return std::move(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::FieldType msg_;
+};
+
+class Init_FieldType_string_capacity
+{
+public:
+  explicit Init_FieldType_string_capacity(::type_description_interfaces::msg::FieldType & msg)
+  : msg_(msg)
+  {}
+  Init_FieldType_nested_type_name string_capacity(::type_description_interfaces::msg::FieldType::_string_capacity_type arg)
+  {
+    msg_.string_capacity = std::move(arg);
+    return Init_FieldType_nested_type_name(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::FieldType msg_;
+};
+
+class Init_FieldType_capacity
+{
+public:
+  explicit Init_FieldType_capacity(::type_description_interfaces::msg::FieldType & msg)
+  : msg_(msg)
+  {}
+  Init_FieldType_string_capacity capacity(::type_description_interfaces::msg::FieldType::_capacity_type arg)
+  {
+    msg_.capacity = std::move(arg);
+    return Init_FieldType_string_capacity(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::FieldType msg_;
+};
+
+class Init_FieldType_type_id
+{
+public:
+  Init_FieldType_type_id()
+  : msg_(::rosidl_runtime_cpp::MessageInitialization::SKIP)
+  {}
+  Init_FieldType_capacity type_id(::type_description_interfaces::msg::FieldType::_type_id_type arg)
+  {
+    msg_.type_id = std::move(arg);
+    return Init_FieldType_capacity(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::FieldType msg_;
+};
+
+}  // namespace builder
+
+}  // namespace msg
+
+template<typename MessageType>
+auto build();
+
+template<>
+inline
+auto build<::type_description_interfaces::msg::FieldType>()
+{
+  return type_description_interfaces::msg::builder::Init_FieldType_type_id();
+}
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__BUILDER_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__functions.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__functions.c
@@ -1,0 +1,276 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `nested_type_name`
+#include "rosidl_runtime_c/string_functions.h"
+
+bool
+type_description_interfaces__msg__FieldType__init(type_description_interfaces__msg__FieldType * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_id
+  msg->type_id = 0;
+  // capacity
+  // string_capacity
+  // nested_type_name
+  if (!rosidl_runtime_c__String__init(&msg->nested_type_name)) {
+    type_description_interfaces__msg__FieldType__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__FieldType__fini(type_description_interfaces__msg__FieldType * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_id
+  // capacity
+  // string_capacity
+  // nested_type_name
+  rosidl_runtime_c__String__fini(&msg->nested_type_name);
+}
+
+bool
+type_description_interfaces__msg__FieldType__are_equal(const type_description_interfaces__msg__FieldType * lhs, const type_description_interfaces__msg__FieldType * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_id
+  if (lhs->type_id != rhs->type_id) {
+    return false;
+  }
+  // capacity
+  if (lhs->capacity != rhs->capacity) {
+    return false;
+  }
+  // string_capacity
+  if (lhs->string_capacity != rhs->string_capacity) {
+    return false;
+  }
+  // nested_type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->nested_type_name), &(rhs->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__FieldType__copy(
+  const type_description_interfaces__msg__FieldType * input,
+  type_description_interfaces__msg__FieldType * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_id
+  output->type_id = input->type_id;
+  // capacity
+  output->capacity = input->capacity;
+  // string_capacity
+  output->string_capacity = input->string_capacity;
+  // nested_type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->nested_type_name), &(output->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__FieldType *
+type_description_interfaces__msg__FieldType__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType * msg = (type_description_interfaces__msg__FieldType *)allocator.allocate(sizeof(type_description_interfaces__msg__FieldType), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__FieldType));
+  bool success = type_description_interfaces__msg__FieldType__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__FieldType__destroy(type_description_interfaces__msg__FieldType * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__FieldType__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__init(type_description_interfaces__msg__FieldType__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__FieldType *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__FieldType), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__FieldType__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__FieldType__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__FieldType__Sequence__fini(type_description_interfaces__msg__FieldType__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__FieldType__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__FieldType__Sequence *
+type_description_interfaces__msg__FieldType__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType__Sequence * array = (type_description_interfaces__msg__FieldType__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__FieldType__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__FieldType__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__FieldType__Sequence__destroy(type_description_interfaces__msg__FieldType__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__FieldType__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__are_equal(const type_description_interfaces__msg__FieldType__Sequence * lhs, const type_description_interfaces__msg__FieldType__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__FieldType__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__copy(
+  const type_description_interfaces__msg__FieldType__Sequence * input,
+  type_description_interfaces__msg__FieldType__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__FieldType);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__FieldType * data =
+      (type_description_interfaces__msg__FieldType *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__FieldType__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__FieldType__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__FieldType__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__functions.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__functions.h
@@ -1,0 +1,177 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__FUNCTIONS_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "type_description_interfaces/msg/detail/field_type__struct.h"
+
+/// Initialize msg/FieldType message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * type_description_interfaces__msg__FieldType
+ * )) before or use
+ * type_description_interfaces__msg__FieldType__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__init(type_description_interfaces__msg__FieldType * msg);
+
+/// Finalize msg/FieldType message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__FieldType__fini(type_description_interfaces__msg__FieldType * msg);
+
+/// Create msg/FieldType message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * type_description_interfaces__msg__FieldType__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__FieldType *
+type_description_interfaces__msg__FieldType__create();
+
+/// Destroy msg/FieldType message.
+/**
+ * It calls
+ * type_description_interfaces__msg__FieldType__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__FieldType__destroy(type_description_interfaces__msg__FieldType * msg);
+
+/// Check for msg/FieldType message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__are_equal(const type_description_interfaces__msg__FieldType * lhs, const type_description_interfaces__msg__FieldType * rhs);
+
+/// Copy a msg/FieldType message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__copy(
+  const type_description_interfaces__msg__FieldType * input,
+  type_description_interfaces__msg__FieldType * output);
+
+/// Initialize array of msg/FieldType messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * type_description_interfaces__msg__FieldType__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__Sequence__init(type_description_interfaces__msg__FieldType__Sequence * array, size_t size);
+
+/// Finalize array of msg/FieldType messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__FieldType__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__FieldType__Sequence__fini(type_description_interfaces__msg__FieldType__Sequence * array);
+
+/// Create array of msg/FieldType messages.
+/**
+ * It allocates the memory for the array and calls
+ * type_description_interfaces__msg__FieldType__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__FieldType__Sequence *
+type_description_interfaces__msg__FieldType__Sequence__create(size_t size);
+
+/// Destroy array of msg/FieldType messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__FieldType__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__FieldType__Sequence__destroy(type_description_interfaces__msg__FieldType__Sequence * array);
+
+/// Check for msg/FieldType message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__Sequence__are_equal(const type_description_interfaces__msg__FieldType__Sequence * lhs, const type_description_interfaces__msg__FieldType__Sequence * rhs);
+
+/// Copy an array of msg/FieldType messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__FieldType__Sequence__copy(
+  const type_description_interfaces__msg__FieldType__Sequence * input,
+  type_description_interfaces__msg__FieldType__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__FUNCTIONS_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_fastrtps_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_fastrtps_c.h
@@ -1,0 +1,37 @@
+// generated from rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+
+
+#include <stddef.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t get_serialized_size_type_description_interfaces__msg__FieldType(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t max_serialized_size_type_description_interfaces__msg__FieldType(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, type_description_interfaces, msg, FieldType)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_fastrtps_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_fastrtps_cpp.hpp
@@ -1,0 +1,80 @@
+// generated from rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h"
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
+#endif
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+#include "fastcdr/Cdr.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace typesupport_fastrtps_cpp
+{
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_serialize(
+  const type_description_interfaces::msg::FieldType & ros_message,
+  eprosima::fastcdr::Cdr & cdr);
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  type_description_interfaces::msg::FieldType & ros_message);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+get_serialized_size(
+  const type_description_interfaces::msg::FieldType & ros_message,
+  size_t current_alignment);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+max_serialized_size_FieldType(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+}  // namespace typesupport_fastrtps_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, type_description_interfaces, msg, FieldType)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_c.h
@@ -1,0 +1,26 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, FieldType)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_cpp.hpp
@@ -1,0 +1,27 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// TODO(dirk-thomas) these visibility macros should be message package specific
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, FieldType)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__struct.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__struct.h
@@ -1,0 +1,660 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+/// Constant 'FIELD_TYPE_NOT_SET'.
+/**
+  * A constant for each type supported according to:
+  *   http://design.ros2.org/articles/legacy_interface_definition.html
+  * and:
+  *   http://design.ros2.org/articles/idl_interface_definition.html
+  * Order is loosely coupled to the order of appearance in the IDL 4.2 spec:
+  *  https://www.omg.org/spec/IDL/4.2
+  * Layout of constants across the 0-255 decimal values in the uint8:
+  *
+  * - 000    : Reserved for "not set"
+  * - 001-048: Primitive types, strings, and reserved space for future primitive types
+  * - 049-096: Fixed sized array of primitive and string types
+  * - 097-144: Bounded Sequences of primitive and string types
+  * - 145-192: Unbounded Sequences of primitive and string types
+  * - 193-255: Reserved space for future array/sequence-like types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_NOT_SET = 0
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE'.
+/**
+  * Nested type defined in other .msg/.idl files.
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_NESTED_TYPE = 1
+};
+
+/// Constant 'FIELD_TYPE_INT8'.
+/**
+  * Integer Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT8 = 2
+};
+
+/// Constant 'FIELD_TYPE_UINT8'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT8 = 3
+};
+
+/// Constant 'FIELD_TYPE_INT16'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT16 = 4
+};
+
+/// Constant 'FIELD_TYPE_UINT16'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT16 = 5
+};
+
+/// Constant 'FIELD_TYPE_INT32'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT32 = 6
+};
+
+/// Constant 'FIELD_TYPE_UINT32'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT32 = 7
+};
+
+/// Constant 'FIELD_TYPE_INT64'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT64 = 8
+};
+
+/// Constant 'FIELD_TYPE_UINT64'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT64 = 9
+};
+
+/// Constant 'FIELD_TYPE_FLOAT'.
+/**
+  * Floating-Point Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FLOAT = 10
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_DOUBLE = 11
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_LONG_DOUBLE = 12
+};
+
+/// Constant 'FIELD_TYPE_CHAR'.
+/**
+  * Char and WChar Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_CHAR = 13
+};
+
+/// Constant 'FIELD_TYPE_WCHAR'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WCHAR = 14
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN'.
+/**
+  * Boolean Type
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOOLEAN = 15
+};
+
+/// Constant 'FIELD_TYPE_BYTE'.
+/**
+  * Byte/Octet Type
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BYTE = 16
+};
+
+/// Constant 'FIELD_TYPE_STRING'.
+/**
+  * String Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_STRING = 17
+};
+
+/// Constant 'FIELD_TYPE_WSTRING'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WSTRING = 18
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING'.
+/**
+  * Fixed String Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_STRING = 19
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_WSTRING = 20
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING'.
+/**
+  * Bounded String Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_STRING = 21
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_WSTRING = 22
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_ARRAY'.
+/**
+  * Fixed Sized Array Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_NESTED_TYPE_ARRAY = 49
+};
+
+/// Constant 'FIELD_TYPE_INT8_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT8_ARRAY = 50
+};
+
+/// Constant 'FIELD_TYPE_UINT8_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT8_ARRAY = 51
+};
+
+/// Constant 'FIELD_TYPE_INT16_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT16_ARRAY = 52
+};
+
+/// Constant 'FIELD_TYPE_UINT16_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT16_ARRAY = 53
+};
+
+/// Constant 'FIELD_TYPE_INT32_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT32_ARRAY = 54
+};
+
+/// Constant 'FIELD_TYPE_UINT32_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT32_ARRAY = 55
+};
+
+/// Constant 'FIELD_TYPE_INT64_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT64_ARRAY = 56
+};
+
+/// Constant 'FIELD_TYPE_UINT64_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT64_ARRAY = 57
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FLOAT_ARRAY = 58
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_DOUBLE_ARRAY = 59
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_LONG_DOUBLE_ARRAY = 60
+};
+
+/// Constant 'FIELD_TYPE_CHAR_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_CHAR_ARRAY = 61
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WCHAR_ARRAY = 62
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOOLEAN_ARRAY = 63
+};
+
+/// Constant 'FIELD_TYPE_BYTE_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BYTE_ARRAY = 64
+};
+
+/// Constant 'FIELD_TYPE_STRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_STRING_ARRAY = 65
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WSTRING_ARRAY = 66
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_STRING_ARRAY = 67
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_WSTRING_ARRAY = 68
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_STRING_ARRAY = 69
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_ARRAY'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_WSTRING_ARRAY = 70
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE'.
+/**
+  * Bounded Sequence Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE = 97
+};
+
+/// Constant 'FIELD_TYPE_INT8_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT8_BOUNDED_SEQUENCE = 98
+};
+
+/// Constant 'FIELD_TYPE_UINT8_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT8_BOUNDED_SEQUENCE = 99
+};
+
+/// Constant 'FIELD_TYPE_INT16_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT16_BOUNDED_SEQUENCE = 100
+};
+
+/// Constant 'FIELD_TYPE_UINT16_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT16_BOUNDED_SEQUENCE = 101
+};
+
+/// Constant 'FIELD_TYPE_INT32_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT32_BOUNDED_SEQUENCE = 102
+};
+
+/// Constant 'FIELD_TYPE_UINT32_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT32_BOUNDED_SEQUENCE = 103
+};
+
+/// Constant 'FIELD_TYPE_INT64_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT64_BOUNDED_SEQUENCE = 104
+};
+
+/// Constant 'FIELD_TYPE_UINT64_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT64_BOUNDED_SEQUENCE = 105
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE = 106
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE = 107
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE = 108
+};
+
+/// Constant 'FIELD_TYPE_CHAR_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_CHAR_BOUNDED_SEQUENCE = 109
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE = 110
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE = 111
+};
+
+/// Constant 'FIELD_TYPE_BYTE_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BYTE_BOUNDED_SEQUENCE = 112
+};
+
+/// Constant 'FIELD_TYPE_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_STRING_BOUNDED_SEQUENCE = 113
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE = 114
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE = 115
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE = 116
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE = 117
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE = 118
+};
+
+/// Constant 'FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE'.
+/**
+  * Unbounded Sequence Types
+ */
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE = 145
+};
+
+/// Constant 'FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE = 146
+};
+
+/// Constant 'FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE = 147
+};
+
+/// Constant 'FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE = 148
+};
+
+/// Constant 'FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE = 149
+};
+
+/// Constant 'FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE = 150
+};
+
+/// Constant 'FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE = 151
+};
+
+/// Constant 'FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE = 152
+};
+
+/// Constant 'FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE = 153
+};
+
+/// Constant 'FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE = 154
+};
+
+/// Constant 'FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE = 155
+};
+
+/// Constant 'FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE = 156
+};
+
+/// Constant 'FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE = 157
+};
+
+/// Constant 'FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE = 158
+};
+
+/// Constant 'FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE = 159
+};
+
+/// Constant 'FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE = 160
+};
+
+/// Constant 'FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE = 161
+};
+
+/// Constant 'FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE = 162
+};
+
+/// Constant 'FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE = 163
+};
+
+/// Constant 'FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE = 164
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE = 165
+};
+
+/// Constant 'FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE'.
+enum
+{
+  type_description_interfaces__msg__FieldType__FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE = 166
+};
+
+// Include directives for member types
+// Member 'nested_type_name'
+#include "rosidl_runtime_c/string.h"
+
+// constants for array fields with an upper bound
+// nested_type_name
+enum
+{
+  type_description_interfaces__msg__FieldType__nested_type_name__MAX_STRING_SIZE = 255
+};
+
+/// Struct defined in msg/FieldType in the package type_description_interfaces.
+/**
+  * Represents the type of a field and related meta-data.
+ */
+typedef struct type_description_interfaces__msg__FieldType
+{
+  /// Identifying number for the type of the field, using one of the above constants.
+  uint8_t type_id;
+  /// Only used when the type is an array or a bounded sequence.
+  /// In the case of an array, this is the fixed capacity of the array.
+  /// In the case of a bounded sequence, this is the maximum capacity of the sequence.
+  /// In all other cases this field is unused.
+  uint64_t capacity;
+  /// Only used when the type is a fixed or bounded string/wstring, or a array/sequence of those.
+  /// In the case of a fixed string/wstring, it is the fixed length of the string.
+  /// In the case of a bounded string/wstring, it is the maximum capacity of the string.
+  /// In the case of an array/sequence of fixed string/wstring, it is the fixed length of the strings.
+  /// In the case of an array/sequence of bounded string/wstring, it is the maximum capacity of the strings.
+  /// It is not currently possible to have different string capacities per element in the array/sequence.
+  uint64_t string_capacity;
+  /// Only used when the type is a nested type or array/sequence of nested types.
+  /// This is limited to 255 characters.
+  /// TODO(wjwwood): this 255 character limit was chosen due to this being the limit
+  ///   for DDSI-RTPS based middlewares, which is the most commonly used right now.
+  ///   We lack a ROS 2 specific limit in our design documents, but we should update
+  ///   this and/or link to the design doc when that is available.
+  rosidl_runtime_c__String nested_type_name;
+} type_description_interfaces__msg__FieldType;
+
+// Struct for a sequence of type_description_interfaces__msg__FieldType.
+typedef struct type_description_interfaces__msg__FieldType__Sequence
+{
+  type_description_interfaces__msg__FieldType * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} type_description_interfaces__msg__FieldType__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__struct.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__struct.hpp
@@ -1,0 +1,547 @@
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+#ifndef _WIN32
+# define DEPRECATED__type_description_interfaces__msg__FieldType __attribute__((deprecated))
+#else
+# define DEPRECATED__type_description_interfaces__msg__FieldType __declspec(deprecated)
+#endif
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+// message struct
+template<class ContainerAllocator>
+struct FieldType_
+{
+  using Type = FieldType_<ContainerAllocator>;
+
+  explicit FieldType_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
+    {
+      this->type_id = 0;
+    } else if (rosidl_runtime_cpp::MessageInitialization::ZERO == _init) {
+      this->type_id = 0;
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+  }
+
+  explicit FieldType_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : nested_type_name(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::DEFAULTS_ONLY == _init)
+    {
+      this->type_id = 0;
+    } else if (rosidl_runtime_cpp::MessageInitialization::ZERO == _init) {
+      this->type_id = 0;
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->capacity = 0ull;
+      this->string_capacity = 0ull;
+      this->nested_type_name = "";
+    }
+  }
+
+  // field types and members
+  using _type_id_type =
+    uint8_t;
+  _type_id_type type_id;
+  using _capacity_type =
+    uint64_t;
+  _capacity_type capacity;
+  using _string_capacity_type =
+    uint64_t;
+  _string_capacity_type string_capacity;
+  using _nested_type_name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _nested_type_name_type nested_type_name;
+
+  // setters for named parameter idiom
+  Type & set__type_id(
+    const uint8_t & _arg)
+  {
+    this->type_id = _arg;
+    return *this;
+  }
+  Type & set__capacity(
+    const uint64_t & _arg)
+  {
+    this->capacity = _arg;
+    return *this;
+  }
+  Type & set__string_capacity(
+    const uint64_t & _arg)
+  {
+    this->string_capacity = _arg;
+    return *this;
+  }
+  Type & set__nested_type_name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->nested_type_name = _arg;
+    return *this;
+  }
+
+  // constant declarations
+  static constexpr uint8_t FIELD_TYPE_NOT_SET =
+    0u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE =
+    1u;
+  static constexpr uint8_t FIELD_TYPE_INT8 =
+    2u;
+  static constexpr uint8_t FIELD_TYPE_UINT8 =
+    3u;
+  static constexpr uint8_t FIELD_TYPE_INT16 =
+    4u;
+  static constexpr uint8_t FIELD_TYPE_UINT16 =
+    5u;
+  static constexpr uint8_t FIELD_TYPE_INT32 =
+    6u;
+  static constexpr uint8_t FIELD_TYPE_UINT32 =
+    7u;
+  static constexpr uint8_t FIELD_TYPE_INT64 =
+    8u;
+  static constexpr uint8_t FIELD_TYPE_UINT64 =
+    9u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT =
+    10u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE =
+    11u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE =
+    12u;
+  static constexpr uint8_t FIELD_TYPE_CHAR =
+    13u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR =
+    14u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN =
+    15u;
+  static constexpr uint8_t FIELD_TYPE_BYTE =
+    16u;
+  static constexpr uint8_t FIELD_TYPE_STRING =
+    17u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING =
+    18u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING =
+    19u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING =
+    20u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING =
+    21u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING =
+    22u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_ARRAY =
+    49u;
+  static constexpr uint8_t FIELD_TYPE_INT8_ARRAY =
+    50u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_ARRAY =
+    51u;
+  static constexpr uint8_t FIELD_TYPE_INT16_ARRAY =
+    52u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_ARRAY =
+    53u;
+  static constexpr uint8_t FIELD_TYPE_INT32_ARRAY =
+    54u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_ARRAY =
+    55u;
+  static constexpr uint8_t FIELD_TYPE_INT64_ARRAY =
+    56u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_ARRAY =
+    57u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_ARRAY =
+    58u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_ARRAY =
+    59u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_ARRAY =
+    60u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_ARRAY =
+    61u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_ARRAY =
+    62u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_ARRAY =
+    63u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_ARRAY =
+    64u;
+  static constexpr uint8_t FIELD_TYPE_STRING_ARRAY =
+    65u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_ARRAY =
+    66u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_ARRAY =
+    67u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_ARRAY =
+    68u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_ARRAY =
+    69u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_ARRAY =
+    70u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE =
+    97u;
+  static constexpr uint8_t FIELD_TYPE_INT8_BOUNDED_SEQUENCE =
+    98u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_BOUNDED_SEQUENCE =
+    99u;
+  static constexpr uint8_t FIELD_TYPE_INT16_BOUNDED_SEQUENCE =
+    100u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_BOUNDED_SEQUENCE =
+    101u;
+  static constexpr uint8_t FIELD_TYPE_INT32_BOUNDED_SEQUENCE =
+    102u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_BOUNDED_SEQUENCE =
+    103u;
+  static constexpr uint8_t FIELD_TYPE_INT64_BOUNDED_SEQUENCE =
+    104u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_BOUNDED_SEQUENCE =
+    105u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE =
+    106u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE =
+    107u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE =
+    108u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_BOUNDED_SEQUENCE =
+    109u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE =
+    110u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE =
+    111u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_BOUNDED_SEQUENCE =
+    112u;
+  static constexpr uint8_t FIELD_TYPE_STRING_BOUNDED_SEQUENCE =
+    113u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE =
+    114u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE =
+    115u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE =
+    116u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE =
+    117u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE =
+    118u;
+  static constexpr uint8_t FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE =
+    145u;
+  static constexpr uint8_t FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE =
+    146u;
+  static constexpr uint8_t FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE =
+    147u;
+  static constexpr uint8_t FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE =
+    148u;
+  static constexpr uint8_t FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE =
+    149u;
+  static constexpr uint8_t FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE =
+    150u;
+  static constexpr uint8_t FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE =
+    151u;
+  static constexpr uint8_t FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE =
+    152u;
+  static constexpr uint8_t FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE =
+    153u;
+  static constexpr uint8_t FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE =
+    154u;
+  static constexpr uint8_t FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE =
+    155u;
+  static constexpr uint8_t FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE =
+    156u;
+  static constexpr uint8_t FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE =
+    157u;
+  static constexpr uint8_t FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE =
+    158u;
+  static constexpr uint8_t FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE =
+    159u;
+  static constexpr uint8_t FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE =
+    160u;
+  static constexpr uint8_t FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE =
+    161u;
+  static constexpr uint8_t FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE =
+    162u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE =
+    163u;
+  static constexpr uint8_t FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE =
+    164u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE =
+    165u;
+  static constexpr uint8_t FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE =
+    166u;
+
+  // pointer types
+  using RawPtr =
+    type_description_interfaces::msg::FieldType_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const type_description_interfaces::msg::FieldType_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::FieldType_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::FieldType_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__type_description_interfaces__msg__FieldType
+    std::shared_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__type_description_interfaces__msg__FieldType
+    std::shared_ptr<type_description_interfaces::msg::FieldType_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const FieldType_ & other) const
+  {
+    if (this->type_id != other.type_id) {
+      return false;
+    }
+    if (this->capacity != other.capacity) {
+      return false;
+    }
+    if (this->string_capacity != other.string_capacity) {
+      return false;
+    }
+    if (this->nested_type_name != other.nested_type_name) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const FieldType_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct FieldType_
+
+// alias to use template instance with default allocator
+using FieldType =
+  type_description_interfaces::msg::FieldType_<std::allocator<void>>;
+
+// constant definitions
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NOT_SET;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_ARRAY;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_BOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_NESTED_TYPE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT8_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT8_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT16_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT16_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT32_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT32_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_INT64_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_UINT64_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FLOAT_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_DOUBLE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_LONG_DOUBLE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_CHAR_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WCHAR_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOOLEAN_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BYTE_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_WSTRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_FIXED_WSTRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_STRING_UNBOUNDED_SEQUENCE;
+template<typename ContainerAllocator>
+constexpr uint8_t FieldType_<ContainerAllocator>::FIELD_TYPE_BOUNDED_WSTRING_UNBOUNDED_SEQUENCE;
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__STRUCT_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__traits.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__traits.hpp
@@ -1,0 +1,160 @@
+// generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TRAITS_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TRAITS_HPP_
+
+#include <stdint.h>
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+#include "rosidl_runtime_cpp/traits.hpp"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+inline void to_flow_style_yaml(
+  const FieldType & msg,
+  std::ostream & out)
+{
+  out << "{";
+  // member: type_id
+  {
+    out << "type_id: ";
+    rosidl_generator_traits::value_to_yaml(msg.type_id, out);
+    out << ", ";
+  }
+
+  // member: capacity
+  {
+    out << "capacity: ";
+    rosidl_generator_traits::value_to_yaml(msg.capacity, out);
+    out << ", ";
+  }
+
+  // member: string_capacity
+  {
+    out << "string_capacity: ";
+    rosidl_generator_traits::value_to_yaml(msg.string_capacity, out);
+    out << ", ";
+  }
+
+  // member: nested_type_name
+  {
+    out << "nested_type_name: ";
+    rosidl_generator_traits::value_to_yaml(msg.nested_type_name, out);
+  }
+  out << "}";
+}  // NOLINT(readability/fn_size)
+
+inline void to_block_style_yaml(
+  const FieldType & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  // member: type_id
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "type_id: ";
+    rosidl_generator_traits::value_to_yaml(msg.type_id, out);
+    out << "\n";
+  }
+
+  // member: capacity
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "capacity: ";
+    rosidl_generator_traits::value_to_yaml(msg.capacity, out);
+    out << "\n";
+  }
+
+  // member: string_capacity
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "string_capacity: ";
+    rosidl_generator_traits::value_to_yaml(msg.string_capacity, out);
+    out << "\n";
+  }
+
+  // member: nested_type_name
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "nested_type_name: ";
+    rosidl_generator_traits::value_to_yaml(msg.nested_type_name, out);
+    out << "\n";
+  }
+}  // NOLINT(readability/fn_size)
+
+inline std::string to_yaml(const FieldType & msg, bool use_flow_style = false)
+{
+  std::ostringstream out;
+  if (use_flow_style) {
+    to_flow_style_yaml(msg, out);
+  } else {
+    to_block_style_yaml(msg, out);
+  }
+  return out.str();
+}
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+namespace rosidl_generator_traits
+{
+
+[[deprecated("use type_description_interfaces::msg::to_block_style_yaml() instead")]]
+inline void to_yaml(
+  const type_description_interfaces::msg::FieldType & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  type_description_interfaces::msg::to_block_style_yaml(msg, out, indentation);
+}
+
+[[deprecated("use type_description_interfaces::msg::to_yaml() instead")]]
+inline std::string to_yaml(const type_description_interfaces::msg::FieldType & msg)
+{
+  return type_description_interfaces::msg::to_yaml(msg);
+}
+
+template<>
+inline const char * data_type<type_description_interfaces::msg::FieldType>()
+{
+  return "type_description_interfaces::msg::FieldType";
+}
+
+template<>
+inline const char * name<type_description_interfaces::msg::FieldType>()
+{
+  return "type_description_interfaces/msg/FieldType";
+}
+
+template<>
+struct has_fixed_size<type_description_interfaces::msg::FieldType>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct has_bounded_size<type_description_interfaces::msg::FieldType>
+  : std::integral_constant<bool, true> {};
+
+template<>
+struct is_message<type_description_interfaces::msg::FieldType>
+  : std::true_type {};
+
+}  // namespace rosidl_generator_traits
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TRAITS_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.c
@@ -1,0 +1,138 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#include <stddef.h>
+#include "type_description_interfaces/msg/detail/field_type__rosidl_typesupport_introspection_c.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+#include "type_description_interfaces/msg/detail/field_type__struct.h"
+
+
+// Include directives for member types
+// Member `nested_type_name`
+#include "rosidl_runtime_c/string_functions.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_init_function(
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
+{
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
+  type_description_interfaces__msg__FieldType__init(message_memory);
+}
+
+void type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_fini_function(void * message_memory)
+{
+  type_description_interfaces__msg__FieldType__fini(message_memory);
+}
+
+static rosidl_typesupport_introspection_c__MessageMember type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_member_array[4] = {
+  {
+    "type_id",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_UINT8,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__FieldType, type_id),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "capacity",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_UINT64,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__FieldType, capacity),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "string_capacity",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_UINT64,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__FieldType, string_capacity),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "nested_type_name",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_STRING,  // type
+    255,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__FieldType, nested_type_name),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  }
+};
+
+static const rosidl_typesupport_introspection_c__MessageMembers type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_members = {
+  "type_description_interfaces__msg",  // message namespace
+  "FieldType",  // message name
+  4,  // number of fields
+  sizeof(type_description_interfaces__msg__FieldType),
+  type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_member_array,  // message members
+  type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_init_function,  // function to initialize message memory (memory has to be allocated)
+  type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_fini_function  // function to terminate message instance (will not free memory)
+};
+
+// this is not const since it must be initialized on first access
+// since C does not allow non-integral compile-time constants
+static rosidl_message_type_support_t type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_type_support_handle = {
+  0,
+  &type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_members,
+  get_message_typesupport_handle_function,
+};
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, FieldType)() {
+  if (!type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_type_support_handle.typesupport_identifier) {
+    type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  return &type_description_interfaces__msg__FieldType__rosidl_typesupport_introspection_c__FieldType_message_type_support_handle;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.cpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.cpp
@@ -1,0 +1,160 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__type_support.cpp.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#include "array"
+#include "cstddef"
+#include "string"
+#include "vector"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+void FieldType_init_function(
+  void * message_memory, rosidl_runtime_cpp::MessageInitialization _init)
+{
+  new (message_memory) type_description_interfaces::msg::FieldType(_init);
+}
+
+void FieldType_fini_function(void * message_memory)
+{
+  auto typed_message = static_cast<type_description_interfaces::msg::FieldType *>(message_memory);
+  typed_message->~FieldType();
+}
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMember FieldType_message_member_array[4] = {
+  {
+    "type_id",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8,  // type
+    0,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::FieldType, type_id),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "capacity",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64,  // type
+    0,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::FieldType, capacity),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "string_capacity",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64,  // type
+    0,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::FieldType, string_capacity),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "nested_type_name",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING,  // type
+    255,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::FieldType, nested_type_name),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  }
+};
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMembers FieldType_message_members = {
+  "type_description_interfaces::msg",  // message namespace
+  "FieldType",  // message name
+  4,  // number of fields
+  sizeof(type_description_interfaces::msg::FieldType),
+  FieldType_message_member_array,  // message members
+  FieldType_init_function,  // function to initialize message memory (memory has to be allocated)
+  FieldType_fini_function  // function to terminate message instance (will not free memory)
+};
+
+static const rosidl_message_type_support_t FieldType_message_type_support_handle = {
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
+  &FieldType_message_members,
+  get_message_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+get_message_type_support_handle<type_description_interfaces::msg::FieldType>()
+{
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::FieldType_message_type_support_handle;
+}
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, FieldType)() {
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::FieldType_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/field_type__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TYPE_SUPPORT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  type_description_interfaces,
+  msg,
+  FieldType
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__FIELD_TYPE__TYPE_SUPPORT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__builder.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__builder.hpp
@@ -1,0 +1,72 @@
+// generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__BUILDER_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__BUILDER_HPP_
+
+#include <algorithm>
+#include <utility>
+
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace builder
+{
+
+class Init_IndividualTypeDescription_fields
+{
+public:
+  explicit Init_IndividualTypeDescription_fields(::type_description_interfaces::msg::IndividualTypeDescription & msg)
+  : msg_(msg)
+  {}
+  ::type_description_interfaces::msg::IndividualTypeDescription fields(::type_description_interfaces::msg::IndividualTypeDescription::_fields_type arg)
+  {
+    msg_.fields = std::move(arg);
+    return std::move(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::IndividualTypeDescription msg_;
+};
+
+class Init_IndividualTypeDescription_type_name
+{
+public:
+  Init_IndividualTypeDescription_type_name()
+  : msg_(::rosidl_runtime_cpp::MessageInitialization::SKIP)
+  {}
+  Init_IndividualTypeDescription_fields type_name(::type_description_interfaces::msg::IndividualTypeDescription::_type_name_type arg)
+  {
+    msg_.type_name = std::move(arg);
+    return Init_IndividualTypeDescription_fields(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::IndividualTypeDescription msg_;
+};
+
+}  // namespace builder
+
+}  // namespace msg
+
+template<typename MessageType>
+auto build();
+
+template<>
+inline
+auto build<::type_description_interfaces::msg::IndividualTypeDescription>()
+{
+  return type_description_interfaces::msg::builder::Init_IndividualTypeDescription_type_name();
+}
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__BUILDER_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__functions.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__functions.c
@@ -1,0 +1,272 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_name`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `fields`
+#include "type_description_interfaces/msg/detail/field__functions.h"
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__init(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__init(&msg->type_name)) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__init(&msg->fields, 0)) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__fini(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_name
+  rosidl_runtime_c__String__fini(&msg->type_name);
+  // fields
+  type_description_interfaces__msg__Field__Sequence__fini(&msg->fields);
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__are_equal(const type_description_interfaces__msg__IndividualTypeDescription * lhs, const type_description_interfaces__msg__IndividualTypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->type_name), &(rhs->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__are_equal(
+      &(lhs->fields), &(rhs->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription * input,
+  type_description_interfaces__msg__IndividualTypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->type_name), &(output->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__copy(
+      &(input->fields), &(output->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__IndividualTypeDescription *
+type_description_interfaces__msg__IndividualTypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription * msg = (type_description_interfaces__msg__IndividualTypeDescription *)allocator.allocate(sizeof(type_description_interfaces__msg__IndividualTypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__IndividualTypeDescription));
+  bool success = type_description_interfaces__msg__IndividualTypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__destroy(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__IndividualTypeDescription *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__IndividualTypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__IndividualTypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__IndividualTypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__IndividualTypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__IndividualTypeDescription__Sequence *
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * array = (type_description_interfaces__msg__IndividualTypeDescription__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__IndividualTypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(const type_description_interfaces__msg__IndividualTypeDescription__Sequence * lhs, const type_description_interfaces__msg__IndividualTypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * input,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__IndividualTypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__IndividualTypeDescription * data =
+      (type_description_interfaces__msg__IndividualTypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__IndividualTypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__IndividualTypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__functions.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__functions.h
@@ -1,0 +1,177 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.h"
+
+/// Initialize msg/IndividualTypeDescription message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * type_description_interfaces__msg__IndividualTypeDescription
+ * )) before or use
+ * type_description_interfaces__msg__IndividualTypeDescription__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__init(type_description_interfaces__msg__IndividualTypeDescription * msg);
+
+/// Finalize msg/IndividualTypeDescription message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__IndividualTypeDescription__fini(type_description_interfaces__msg__IndividualTypeDescription * msg);
+
+/// Create msg/IndividualTypeDescription message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * type_description_interfaces__msg__IndividualTypeDescription__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__IndividualTypeDescription *
+type_description_interfaces__msg__IndividualTypeDescription__create();
+
+/// Destroy msg/IndividualTypeDescription message.
+/**
+ * It calls
+ * type_description_interfaces__msg__IndividualTypeDescription__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__IndividualTypeDescription__destroy(type_description_interfaces__msg__IndividualTypeDescription * msg);
+
+/// Check for msg/IndividualTypeDescription message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__are_equal(const type_description_interfaces__msg__IndividualTypeDescription * lhs, const type_description_interfaces__msg__IndividualTypeDescription * rhs);
+
+/// Copy a msg/IndividualTypeDescription message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription * input,
+  type_description_interfaces__msg__IndividualTypeDescription * output);
+
+/// Initialize array of msg/IndividualTypeDescription messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * type_description_interfaces__msg__IndividualTypeDescription__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array, size_t size);
+
+/// Finalize array of msg/IndividualTypeDescription messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__IndividualTypeDescription__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array);
+
+/// Create array of msg/IndividualTypeDescription messages.
+/**
+ * It allocates the memory for the array and calls
+ * type_description_interfaces__msg__IndividualTypeDescription__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__IndividualTypeDescription__Sequence *
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(size_t size);
+
+/// Destroy array of msg/IndividualTypeDescription messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array);
+
+/// Check for msg/IndividualTypeDescription message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(const type_description_interfaces__msg__IndividualTypeDescription__Sequence * lhs, const type_description_interfaces__msg__IndividualTypeDescription__Sequence * rhs);
+
+/// Copy an array of msg/IndividualTypeDescription messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * input,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__FUNCTIONS_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_fastrtps_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_fastrtps_c.h
@@ -1,0 +1,37 @@
+// generated from rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+
+
+#include <stddef.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t get_serialized_size_type_description_interfaces__msg__IndividualTypeDescription(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t max_serialized_size_type_description_interfaces__msg__IndividualTypeDescription(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, type_description_interfaces, msg, IndividualTypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_fastrtps_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_fastrtps_cpp.hpp
@@ -1,0 +1,80 @@
+// generated from rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
+#endif
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+#include "fastcdr/Cdr.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace typesupport_fastrtps_cpp
+{
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_serialize(
+  const type_description_interfaces::msg::IndividualTypeDescription & ros_message,
+  eprosima::fastcdr::Cdr & cdr);
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  type_description_interfaces::msg::IndividualTypeDescription & ros_message);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+get_serialized_size(
+  const type_description_interfaces::msg::IndividualTypeDescription & ros_message,
+  size_t current_alignment);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+max_serialized_size_IndividualTypeDescription(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+}  // namespace typesupport_fastrtps_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, type_description_interfaces, msg, IndividualTypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_c.h
@@ -1,0 +1,26 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, IndividualTypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_cpp.hpp
@@ -1,0 +1,27 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// TODO(dirk-thomas) these visibility macros should be message package specific
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, IndividualTypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__struct.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__struct.h
@@ -1,0 +1,64 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'type_name'
+#include "rosidl_runtime_c/string.h"
+// Member 'fields'
+#include "type_description_interfaces/msg/detail/field__struct.h"
+
+// constants for array fields with an upper bound
+// type_name
+enum
+{
+  type_description_interfaces__msg__IndividualTypeDescription__type_name__MAX_STRING_SIZE = 255
+};
+
+/// Struct defined in msg/IndividualTypeDescription in the package type_description_interfaces.
+/**
+  * Represents a single type, without the types it references, if any.
+ */
+typedef struct type_description_interfaces__msg__IndividualTypeDescription
+{
+  /// Name of the type.
+  /// This is limited to 255 characters.
+  /// TODO(wjwwood): this 255 character limit was chosen due to this being the limit
+  ///   for DDSI-RTPS based middlewares, which is the most commonly used right now.
+  ///   We lack a ROS 2 specific limit in our design documents, but we should update
+  ///   this and/or link to the design doc when that is available.
+  rosidl_runtime_c__String type_name;
+  /// Fields of the type.
+  type_description_interfaces__msg__Field__Sequence fields;
+} type_description_interfaces__msg__IndividualTypeDescription;
+
+// Struct for a sequence of type_description_interfaces__msg__IndividualTypeDescription.
+typedef struct type_description_interfaces__msg__IndividualTypeDescription__Sequence
+{
+  type_description_interfaces__msg__IndividualTypeDescription * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} type_description_interfaces__msg__IndividualTypeDescription__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__struct.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__struct.hpp
@@ -1,0 +1,147 @@
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'fields'
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__type_description_interfaces__msg__IndividualTypeDescription __attribute__((deprecated))
+#else
+# define DEPRECATED__type_description_interfaces__msg__IndividualTypeDescription __declspec(deprecated)
+#endif
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+// message struct
+template<class ContainerAllocator>
+struct IndividualTypeDescription_
+{
+  using Type = IndividualTypeDescription_<ContainerAllocator>;
+
+  explicit IndividualTypeDescription_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+    }
+  }
+
+  explicit IndividualTypeDescription_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_name(_alloc)
+  {
+    if (rosidl_runtime_cpp::MessageInitialization::ALL == _init ||
+      rosidl_runtime_cpp::MessageInitialization::ZERO == _init)
+    {
+      this->type_name = "";
+    }
+  }
+
+  // field types and members
+  using _type_name_type =
+    std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>;
+  _type_name_type type_name;
+  using _fields_type =
+    std::vector<type_description_interfaces::msg::Field_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<type_description_interfaces::msg::Field_<ContainerAllocator>>>;
+  _fields_type fields;
+
+  // setters for named parameter idiom
+  Type & set__type_name(
+    const std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>> & _arg)
+  {
+    this->type_name = _arg;
+    return *this;
+  }
+  Type & set__fields(
+    const std::vector<type_description_interfaces::msg::Field_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<type_description_interfaces::msg::Field_<ContainerAllocator>>> & _arg)
+  {
+    this->fields = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__type_description_interfaces__msg__IndividualTypeDescription
+    std::shared_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__type_description_interfaces__msg__IndividualTypeDescription
+    std::shared_ptr<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const IndividualTypeDescription_ & other) const
+  {
+    if (this->type_name != other.type_name) {
+      return false;
+    }
+    if (this->fields != other.fields) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const IndividualTypeDescription_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct IndividualTypeDescription_
+
+// alias to use template instance with default allocator
+using IndividualTypeDescription =
+  type_description_interfaces::msg::IndividualTypeDescription_<std::allocator<void>>;
+
+// constant definitions
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__STRUCT_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__traits.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__traits.hpp
@@ -1,0 +1,150 @@
+// generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TRAITS_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TRAITS_HPP_
+
+#include <stdint.h>
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+#include "rosidl_runtime_cpp/traits.hpp"
+
+// Include directives for member types
+// Member 'fields'
+#include "type_description_interfaces/msg/detail/field__traits.hpp"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+inline void to_flow_style_yaml(
+  const IndividualTypeDescription & msg,
+  std::ostream & out)
+{
+  out << "{";
+  // member: type_name
+  {
+    out << "type_name: ";
+    rosidl_generator_traits::value_to_yaml(msg.type_name, out);
+    out << ", ";
+  }
+
+  // member: fields
+  {
+    if (msg.fields.size() == 0) {
+      out << "fields: []";
+    } else {
+      out << "fields: [";
+      size_t pending_items = msg.fields.size();
+      for (auto item : msg.fields) {
+        to_flow_style_yaml(item, out);
+        if (--pending_items > 0) {
+          out << ", ";
+        }
+      }
+      out << "]";
+    }
+  }
+  out << "}";
+}  // NOLINT(readability/fn_size)
+
+inline void to_block_style_yaml(
+  const IndividualTypeDescription & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  // member: type_name
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "type_name: ";
+    rosidl_generator_traits::value_to_yaml(msg.type_name, out);
+    out << "\n";
+  }
+
+  // member: fields
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    if (msg.fields.size() == 0) {
+      out << "fields: []\n";
+    } else {
+      out << "fields:\n";
+      for (auto item : msg.fields) {
+        if (indentation > 0) {
+          out << std::string(indentation, ' ');
+        }
+        out << "-\n";
+        to_block_style_yaml(item, out, indentation + 2);
+      }
+    }
+  }
+}  // NOLINT(readability/fn_size)
+
+inline std::string to_yaml(const IndividualTypeDescription & msg, bool use_flow_style = false)
+{
+  std::ostringstream out;
+  if (use_flow_style) {
+    to_flow_style_yaml(msg, out);
+  } else {
+    to_block_style_yaml(msg, out);
+  }
+  return out.str();
+}
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+namespace rosidl_generator_traits
+{
+
+[[deprecated("use type_description_interfaces::msg::to_block_style_yaml() instead")]]
+inline void to_yaml(
+  const type_description_interfaces::msg::IndividualTypeDescription & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  type_description_interfaces::msg::to_block_style_yaml(msg, out, indentation);
+}
+
+[[deprecated("use type_description_interfaces::msg::to_yaml() instead")]]
+inline std::string to_yaml(const type_description_interfaces::msg::IndividualTypeDescription & msg)
+{
+  return type_description_interfaces::msg::to_yaml(msg);
+}
+
+template<>
+inline const char * data_type<type_description_interfaces::msg::IndividualTypeDescription>()
+{
+  return "type_description_interfaces::msg::IndividualTypeDescription";
+}
+
+template<>
+inline const char * name<type_description_interfaces::msg::IndividualTypeDescription>()
+{
+  return "type_description_interfaces/msg/IndividualTypeDescription";
+}
+
+template<>
+struct has_fixed_size<type_description_interfaces::msg::IndividualTypeDescription>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct has_bounded_size<type_description_interfaces::msg::IndividualTypeDescription>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct is_message<type_description_interfaces::msg::IndividualTypeDescription>
+  : std::true_type {};
+
+}  // namespace rosidl_generator_traits
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TRAITS_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.c
@@ -1,0 +1,165 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include <stddef.h>
+#include "type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_c.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.h"
+
+
+// Include directives for member types
+// Member `type_name`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `fields`
+#include "type_description_interfaces/msg/field.h"
+// Member `fields`
+#include "type_description_interfaces/msg/detail/field__rosidl_typesupport_introspection_c.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_init_function(
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
+{
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
+  type_description_interfaces__msg__IndividualTypeDescription__init(message_memory);
+}
+
+void type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_fini_function(void * message_memory)
+{
+  type_description_interfaces__msg__IndividualTypeDescription__fini(message_memory);
+}
+
+size_t type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__size_function__IndividualTypeDescription__fields(
+  const void * untyped_member)
+{
+  const type_description_interfaces__msg__Field__Sequence * member =
+    (const type_description_interfaces__msg__Field__Sequence *)(untyped_member);
+  return member->size;
+}
+
+const void * type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_const_function__IndividualTypeDescription__fields(
+  const void * untyped_member, size_t index)
+{
+  const type_description_interfaces__msg__Field__Sequence * member =
+    (const type_description_interfaces__msg__Field__Sequence *)(untyped_member);
+  return &member->data[index];
+}
+
+void * type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_function__IndividualTypeDescription__fields(
+  void * untyped_member, size_t index)
+{
+  type_description_interfaces__msg__Field__Sequence * member =
+    (type_description_interfaces__msg__Field__Sequence *)(untyped_member);
+  return &member->data[index];
+}
+
+void type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__fetch_function__IndividualTypeDescription__fields(
+  const void * untyped_member, size_t index, void * untyped_value)
+{
+  const type_description_interfaces__msg__Field * item =
+    ((const type_description_interfaces__msg__Field *)
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_const_function__IndividualTypeDescription__fields(untyped_member, index));
+  type_description_interfaces__msg__Field * value =
+    (type_description_interfaces__msg__Field *)(untyped_value);
+  *value = *item;
+}
+
+void type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__assign_function__IndividualTypeDescription__fields(
+  void * untyped_member, size_t index, const void * untyped_value)
+{
+  type_description_interfaces__msg__Field * item =
+    ((type_description_interfaces__msg__Field *)
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_function__IndividualTypeDescription__fields(untyped_member, index));
+  const type_description_interfaces__msg__Field * value =
+    (const type_description_interfaces__msg__Field *)(untyped_value);
+  *item = *value;
+}
+
+bool type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__resize_function__IndividualTypeDescription__fields(
+  void * untyped_member, size_t size)
+{
+  type_description_interfaces__msg__Field__Sequence * member =
+    (type_description_interfaces__msg__Field__Sequence *)(untyped_member);
+  type_description_interfaces__msg__Field__Sequence__fini(member);
+  return type_description_interfaces__msg__Field__Sequence__init(member, size);
+}
+
+static rosidl_typesupport_introspection_c__MessageMember type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_member_array[2] = {
+  {
+    "type_name",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_STRING,  // type
+    255,  // upper bound of string
+    NULL,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__IndividualTypeDescription, type_name),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "fields",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message (initialized later)
+    true,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__IndividualTypeDescription, fields),  // bytes offset in struct
+    NULL,  // default value
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__size_function__IndividualTypeDescription__fields,  // size() function pointer
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_const_function__IndividualTypeDescription__fields,  // get_const(index) function pointer
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__get_function__IndividualTypeDescription__fields,  // get(index) function pointer
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__fetch_function__IndividualTypeDescription__fields,  // fetch(index, &value) function pointer
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__assign_function__IndividualTypeDescription__fields,  // assign(index, value) function pointer
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__resize_function__IndividualTypeDescription__fields  // resize(index) function pointer
+  }
+};
+
+static const rosidl_typesupport_introspection_c__MessageMembers type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_members = {
+  "type_description_interfaces__msg",  // message namespace
+  "IndividualTypeDescription",  // message name
+  2,  // number of fields
+  sizeof(type_description_interfaces__msg__IndividualTypeDescription),
+  type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_member_array,  // message members
+  type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_init_function,  // function to initialize message memory (memory has to be allocated)
+  type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_fini_function  // function to terminate message instance (will not free memory)
+};
+
+// this is not const since it must be initialized on first access
+// since C does not allow non-integral compile-time constants
+static rosidl_message_type_support_t type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_type_support_handle = {
+  0,
+  &type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_members,
+  get_message_typesupport_handle_function,
+};
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, IndividualTypeDescription)() {
+  type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_member_array[1].members_ =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, Field)();
+  if (!type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_type_support_handle.typesupport_identifier) {
+    type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  return &type_description_interfaces__msg__IndividualTypeDescription__rosidl_typesupport_introspection_c__IndividualTypeDescription_message_type_support_handle;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.cpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.cpp
@@ -1,0 +1,171 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__type_support.cpp.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include "array"
+#include "cstddef"
+#include "string"
+#include "vector"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+void IndividualTypeDescription_init_function(
+  void * message_memory, rosidl_runtime_cpp::MessageInitialization _init)
+{
+  new (message_memory) type_description_interfaces::msg::IndividualTypeDescription(_init);
+}
+
+void IndividualTypeDescription_fini_function(void * message_memory)
+{
+  auto typed_message = static_cast<type_description_interfaces::msg::IndividualTypeDescription *>(message_memory);
+  typed_message->~IndividualTypeDescription();
+}
+
+size_t size_function__IndividualTypeDescription__fields(const void * untyped_member)
+{
+  const auto * member = reinterpret_cast<const std::vector<type_description_interfaces::msg::Field> *>(untyped_member);
+  return member->size();
+}
+
+const void * get_const_function__IndividualTypeDescription__fields(const void * untyped_member, size_t index)
+{
+  const auto & member =
+    *reinterpret_cast<const std::vector<type_description_interfaces::msg::Field> *>(untyped_member);
+  return &member[index];
+}
+
+void * get_function__IndividualTypeDescription__fields(void * untyped_member, size_t index)
+{
+  auto & member =
+    *reinterpret_cast<std::vector<type_description_interfaces::msg::Field> *>(untyped_member);
+  return &member[index];
+}
+
+void fetch_function__IndividualTypeDescription__fields(
+  const void * untyped_member, size_t index, void * untyped_value)
+{
+  const auto & item = *reinterpret_cast<const type_description_interfaces::msg::Field *>(
+    get_const_function__IndividualTypeDescription__fields(untyped_member, index));
+  auto & value = *reinterpret_cast<type_description_interfaces::msg::Field *>(untyped_value);
+  value = item;
+}
+
+void assign_function__IndividualTypeDescription__fields(
+  void * untyped_member, size_t index, const void * untyped_value)
+{
+  auto & item = *reinterpret_cast<type_description_interfaces::msg::Field *>(
+    get_function__IndividualTypeDescription__fields(untyped_member, index));
+  const auto & value = *reinterpret_cast<const type_description_interfaces::msg::Field *>(untyped_value);
+  item = value;
+}
+
+void resize_function__IndividualTypeDescription__fields(void * untyped_member, size_t size)
+{
+  auto * member =
+    reinterpret_cast<std::vector<type_description_interfaces::msg::Field> *>(untyped_member);
+  member->resize(size);
+}
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMember IndividualTypeDescription_message_member_array[2] = {
+  {
+    "type_name",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING,  // type
+    255,  // upper bound of string
+    nullptr,  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::IndividualTypeDescription, type_name),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "fields",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<type_description_interfaces::msg::Field>(),  // members of sub message
+    true,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::IndividualTypeDescription, fields),  // bytes offset in struct
+    nullptr,  // default value
+    size_function__IndividualTypeDescription__fields,  // size() function pointer
+    get_const_function__IndividualTypeDescription__fields,  // get_const(index) function pointer
+    get_function__IndividualTypeDescription__fields,  // get(index) function pointer
+    fetch_function__IndividualTypeDescription__fields,  // fetch(index, &value) function pointer
+    assign_function__IndividualTypeDescription__fields,  // assign(index, value) function pointer
+    resize_function__IndividualTypeDescription__fields  // resize(index) function pointer
+  }
+};
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMembers IndividualTypeDescription_message_members = {
+  "type_description_interfaces::msg",  // message namespace
+  "IndividualTypeDescription",  // message name
+  2,  // number of fields
+  sizeof(type_description_interfaces::msg::IndividualTypeDescription),
+  IndividualTypeDescription_message_member_array,  // message members
+  IndividualTypeDescription_init_function,  // function to initialize message memory (memory has to be allocated)
+  IndividualTypeDescription_fini_function  // function to terminate message instance (will not free memory)
+};
+
+static const rosidl_message_type_support_t IndividualTypeDescription_message_type_support_handle = {
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
+  &IndividualTypeDescription_message_members,
+  get_message_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+get_message_type_support_handle<type_description_interfaces::msg::IndividualTypeDescription>()
+{
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::IndividualTypeDescription_message_type_support_handle;
+}
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, IndividualTypeDescription)() {
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::IndividualTypeDescription_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/individual_type_description__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TYPE_SUPPORT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  type_description_interfaces,
+  msg,
+  IndividualTypeDescription
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__INDIVIDUAL_TYPE_DESCRIPTION__TYPE_SUPPORT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__builder.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__builder.hpp
@@ -1,0 +1,72 @@
+// generated from rosidl_generator_cpp/resource/idl__builder.hpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__BUILDER_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__BUILDER_HPP_
+
+#include <algorithm>
+#include <utility>
+
+#include "type_description_interfaces/msg/detail/type_description__struct.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace builder
+{
+
+class Init_TypeDescription_referenced_type_descriptions
+{
+public:
+  explicit Init_TypeDescription_referenced_type_descriptions(::type_description_interfaces::msg::TypeDescription & msg)
+  : msg_(msg)
+  {}
+  ::type_description_interfaces::msg::TypeDescription referenced_type_descriptions(::type_description_interfaces::msg::TypeDescription::_referenced_type_descriptions_type arg)
+  {
+    msg_.referenced_type_descriptions = std::move(arg);
+    return std::move(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::TypeDescription msg_;
+};
+
+class Init_TypeDescription_type_description
+{
+public:
+  Init_TypeDescription_type_description()
+  : msg_(::rosidl_runtime_cpp::MessageInitialization::SKIP)
+  {}
+  Init_TypeDescription_referenced_type_descriptions type_description(::type_description_interfaces::msg::TypeDescription::_type_description_type arg)
+  {
+    msg_.type_description = std::move(arg);
+    return Init_TypeDescription_referenced_type_descriptions(msg_);
+  }
+
+private:
+  ::type_description_interfaces::msg::TypeDescription msg_;
+};
+
+}  // namespace builder
+
+}  // namespace msg
+
+template<typename MessageType>
+auto build();
+
+template<>
+inline
+auto build<::type_description_interfaces::msg::TypeDescription>()
+{
+  return type_description_interfaces::msg::builder::Init_TypeDescription_type_description();
+}
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__BUILDER_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__functions.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__functions.c
@@ -1,0 +1,271 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_description`
+// Member `referenced_type_descriptions`
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+
+bool
+type_description_interfaces__msg__TypeDescription__init(type_description_interfaces__msg__TypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__init(&msg->type_description)) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(&msg->referenced_type_descriptions, 0)) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__fini(type_description_interfaces__msg__TypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_description
+  type_description_interfaces__msg__IndividualTypeDescription__fini(&msg->type_description);
+  // referenced_type_descriptions
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(&msg->referenced_type_descriptions);
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__are_equal(const type_description_interfaces__msg__TypeDescription * lhs, const type_description_interfaces__msg__TypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &(lhs->type_description), &(rhs->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(
+      &(lhs->referenced_type_descriptions), &(rhs->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__copy(
+  const type_description_interfaces__msg__TypeDescription * input,
+  type_description_interfaces__msg__TypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+      &(input->type_description), &(output->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+      &(input->referenced_type_descriptions), &(output->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__TypeDescription *
+type_description_interfaces__msg__TypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription * msg = (type_description_interfaces__msg__TypeDescription *)allocator.allocate(sizeof(type_description_interfaces__msg__TypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__TypeDescription));
+  bool success = type_description_interfaces__msg__TypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__destroy(type_description_interfaces__msg__TypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__init(type_description_interfaces__msg__TypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__TypeDescription *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__TypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__TypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__TypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__Sequence__fini(type_description_interfaces__msg__TypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__TypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__TypeDescription__Sequence *
+type_description_interfaces__msg__TypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription__Sequence * array = (type_description_interfaces__msg__TypeDescription__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__TypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__TypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__Sequence__destroy(type_description_interfaces__msg__TypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__TypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__are_equal(const type_description_interfaces__msg__TypeDescription__Sequence * lhs, const type_description_interfaces__msg__TypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__TypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__TypeDescription__Sequence * input,
+  type_description_interfaces__msg__TypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__TypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__TypeDescription * data =
+      (type_description_interfaces__msg__TypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__TypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__TypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__TypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__functions.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__functions.h
@@ -1,0 +1,177 @@
+// generated from rosidl_generator_c/resource/idl__functions.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__FUNCTIONS_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__FUNCTIONS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "rosidl_runtime_c/visibility_control.h"
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#include "type_description_interfaces/msg/detail/type_description__struct.h"
+
+/// Initialize msg/TypeDescription message.
+/**
+ * If the init function is called twice for the same message without
+ * calling fini inbetween previously allocated memory will be leaked.
+ * \param[in,out] msg The previously allocated message pointer.
+ * Fields without a default value will not be initialized by this function.
+ * You might want to call memset(msg, 0, sizeof(
+ * type_description_interfaces__msg__TypeDescription
+ * )) before or use
+ * type_description_interfaces__msg__TypeDescription__create()
+ * to allocate and initialize the message.
+ * \return true if initialization was successful, otherwise false
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__init(type_description_interfaces__msg__TypeDescription * msg);
+
+/// Finalize msg/TypeDescription message.
+/**
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__TypeDescription__fini(type_description_interfaces__msg__TypeDescription * msg);
+
+/// Create msg/TypeDescription message.
+/**
+ * It allocates the memory for the message, sets the memory to zero, and
+ * calls
+ * type_description_interfaces__msg__TypeDescription__init().
+ * \return The pointer to the initialized message if successful,
+ * otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__TypeDescription *
+type_description_interfaces__msg__TypeDescription__create();
+
+/// Destroy msg/TypeDescription message.
+/**
+ * It calls
+ * type_description_interfaces__msg__TypeDescription__fini()
+ * and frees the memory of the message.
+ * \param[in,out] msg The allocated message pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__TypeDescription__destroy(type_description_interfaces__msg__TypeDescription * msg);
+
+/// Check for msg/TypeDescription message equality.
+/**
+ * \param[in] lhs The message on the left hand size of the equality operator.
+ * \param[in] rhs The message on the right hand size of the equality operator.
+ * \return true if messages are equal, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__are_equal(const type_description_interfaces__msg__TypeDescription * lhs, const type_description_interfaces__msg__TypeDescription * rhs);
+
+/// Copy a msg/TypeDescription message.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source message pointer.
+ * \param[out] output The target message pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer is null
+ *   or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__copy(
+  const type_description_interfaces__msg__TypeDescription * input,
+  type_description_interfaces__msg__TypeDescription * output);
+
+/// Initialize array of msg/TypeDescription messages.
+/**
+ * It allocates the memory for the number of elements and calls
+ * type_description_interfaces__msg__TypeDescription__init()
+ * for each element of the array.
+ * \param[in,out] array The allocated array pointer.
+ * \param[in] size The size / capacity of the array.
+ * \return true if initialization was successful, otherwise false
+ * If the array pointer is valid and the size is zero it is guaranteed
+ # to return true.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__init(type_description_interfaces__msg__TypeDescription__Sequence * array, size_t size);
+
+/// Finalize array of msg/TypeDescription messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__TypeDescription__fini()
+ * for each element of the array and frees the memory for the number of
+ * elements.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__TypeDescription__Sequence__fini(type_description_interfaces__msg__TypeDescription__Sequence * array);
+
+/// Create array of msg/TypeDescription messages.
+/**
+ * It allocates the memory for the array and calls
+ * type_description_interfaces__msg__TypeDescription__Sequence__init().
+ * \param[in] size The size / capacity of the array.
+ * \return The pointer to the initialized array if successful, otherwise NULL
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+type_description_interfaces__msg__TypeDescription__Sequence *
+type_description_interfaces__msg__TypeDescription__Sequence__create(size_t size);
+
+/// Destroy array of msg/TypeDescription messages.
+/**
+ * It calls
+ * type_description_interfaces__msg__TypeDescription__Sequence__fini()
+ * on the array,
+ * and frees the memory of the array.
+ * \param[in,out] array The initialized array pointer.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+void
+type_description_interfaces__msg__TypeDescription__Sequence__destroy(type_description_interfaces__msg__TypeDescription__Sequence * array);
+
+/// Check for msg/TypeDescription message array equality.
+/**
+ * \param[in] lhs The message array on the left hand size of the equality operator.
+ * \param[in] rhs The message array on the right hand size of the equality operator.
+ * \return true if message arrays are equal in size and content, otherwise false.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__are_equal(const type_description_interfaces__msg__TypeDescription__Sequence * lhs, const type_description_interfaces__msg__TypeDescription__Sequence * rhs);
+
+/// Copy an array of msg/TypeDescription messages.
+/**
+ * This functions performs a deep copy, as opposed to the shallow copy that
+ * plain assignment yields.
+ *
+ * \param[in] input The source array pointer.
+ * \param[out] output The target array pointer, which must
+ *   have been initialized before calling this function.
+ * \return true if successful, or false if either pointer
+ *   is null or memory allocation fails.
+ */
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__TypeDescription__Sequence * input,
+  type_description_interfaces__msg__TypeDescription__Sequence * output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__FUNCTIONS_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_fastrtps_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_fastrtps_c.h
@@ -1,0 +1,37 @@
+// generated from rosidl_typesupport_fastrtps_c/resource/idl__rosidl_typesupport_fastrtps_c.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_
+
+
+#include <stddef.h>
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t get_serialized_size_type_description_interfaces__msg__TypeDescription(
+  const void * untyped_ros_message,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+size_t max_serialized_size_type_description_interfaces__msg__TypeDescription(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_c, type_description_interfaces, msg, TypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_fastrtps_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_fastrtps_cpp.hpp
@@ -1,0 +1,80 @@
+// generated from rosidl_typesupport_fastrtps_cpp/resource/idl__rosidl_typesupport_fastrtps_cpp.hpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h"
+#include "type_description_interfaces/msg/detail/type_description__struct.hpp"
+
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wunused-parameter"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
+#endif
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
+#include "fastcdr/Cdr.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace typesupport_fastrtps_cpp
+{
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_serialize(
+  const type_description_interfaces::msg::TypeDescription & ros_message,
+  eprosima::fastcdr::Cdr & cdr);
+
+bool
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+cdr_deserialize(
+  eprosima::fastcdr::Cdr & cdr,
+  type_description_interfaces::msg::TypeDescription & ros_message);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+get_serialized_size(
+  const type_description_interfaces::msg::TypeDescription & ros_message,
+  size_t current_alignment);
+
+size_t
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+max_serialized_size_TypeDescription(
+  bool & full_bounded,
+  bool & is_plain,
+  size_t current_alignment);
+
+}  // namespace typesupport_fastrtps_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_fastrtps_cpp, type_description_interfaces, msg, TypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_FASTRTPS_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_introspection_c.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_introspection_c.h
@@ -1,0 +1,26 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__rosidl_typesupport_introspection_c.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, TypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_C_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_introspection_cpp.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__rosidl_typesupport_introspection_cpp.hpp
@@ -1,0 +1,27 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__rosidl_typesupport_introspection_cpp.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_
+
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// TODO(dirk-thomas) these visibility macros should be message package specific
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, TypeDescription)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__struct.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__struct.h
@@ -1,0 +1,51 @@
+// generated from rosidl_generator_c/resource/idl__struct.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+
+// Constants defined in the message
+
+// Include directives for member types
+// Member 'type_description'
+// Member 'referenced_type_descriptions'
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.h"
+
+/// Struct defined in msg/TypeDescription in the package type_description_interfaces.
+/**
+  * Represents a complete type description, including the type itself as well as the types it references.
+ */
+typedef struct type_description_interfaces__msg__TypeDescription
+{
+  /// Description of the type.
+  type_description_interfaces__msg__IndividualTypeDescription type_description;
+  /// Descriptions of all referenced types, recursively.
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence referenced_type_descriptions;
+} type_description_interfaces__msg__TypeDescription;
+
+// Struct for a sequence of type_description_interfaces__msg__TypeDescription.
+typedef struct type_description_interfaces__msg__TypeDescription__Sequence
+{
+  type_description_interfaces__msg__TypeDescription * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} type_description_interfaces__msg__TypeDescription__Sequence;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__struct.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__struct.hpp
@@ -1,0 +1,141 @@
+// generated from rosidl_generator_cpp/resource/idl__struct.hpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_HPP_
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rosidl_runtime_cpp/bounded_vector.hpp"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
+
+
+// Include directives for member types
+// Member 'type_description'
+// Member 'referenced_type_descriptions'
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+
+#ifndef _WIN32
+# define DEPRECATED__type_description_interfaces__msg__TypeDescription __attribute__((deprecated))
+#else
+# define DEPRECATED__type_description_interfaces__msg__TypeDescription __declspec(deprecated)
+#endif
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+// message struct
+template<class ContainerAllocator>
+struct TypeDescription_
+{
+  using Type = TypeDescription_<ContainerAllocator>;
+
+  explicit TypeDescription_(rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_description(_init)
+  {
+    (void)_init;
+  }
+
+  explicit TypeDescription_(const ContainerAllocator & _alloc, rosidl_runtime_cpp::MessageInitialization _init = rosidl_runtime_cpp::MessageInitialization::ALL)
+  : type_description(_alloc, _init)
+  {
+    (void)_init;
+  }
+
+  // field types and members
+  using _type_description_type =
+    type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>;
+  _type_description_type type_description;
+  using _referenced_type_descriptions_type =
+    std::vector<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>>;
+  _referenced_type_descriptions_type referenced_type_descriptions;
+
+  // setters for named parameter idiom
+  Type & set__type_description(
+    const type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator> & _arg)
+  {
+    this->type_description = _arg;
+    return *this;
+  }
+  Type & set__referenced_type_descriptions(
+    const std::vector<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<type_description_interfaces::msg::IndividualTypeDescription_<ContainerAllocator>>> & _arg)
+  {
+    this->referenced_type_descriptions = _arg;
+    return *this;
+  }
+
+  // constant declarations
+
+  // pointer types
+  using RawPtr =
+    type_description_interfaces::msg::TypeDescription_<ContainerAllocator> *;
+  using ConstRawPtr =
+    const type_description_interfaces::msg::TypeDescription_<ContainerAllocator> *;
+  using SharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator>>;
+  using ConstSharedPtr =
+    std::shared_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator> const>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::TypeDescription_<ContainerAllocator>>>
+  using UniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator>, Deleter>;
+
+  using UniquePtr = UniquePtrWithDeleter<>;
+
+  template<typename Deleter = std::default_delete<
+      type_description_interfaces::msg::TypeDescription_<ContainerAllocator>>>
+  using ConstUniquePtrWithDeleter =
+    std::unique_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator> const, Deleter>;
+  using ConstUniquePtr = ConstUniquePtrWithDeleter<>;
+
+  using WeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator>>;
+  using ConstWeakPtr =
+    std::weak_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator> const>;
+
+  // pointer types similar to ROS 1, use SharedPtr / ConstSharedPtr instead
+  // NOTE: Can't use 'using' here because GNU C++ can't parse attributes properly
+  typedef DEPRECATED__type_description_interfaces__msg__TypeDescription
+    std::shared_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator>>
+    Ptr;
+  typedef DEPRECATED__type_description_interfaces__msg__TypeDescription
+    std::shared_ptr<type_description_interfaces::msg::TypeDescription_<ContainerAllocator> const>
+    ConstPtr;
+
+  // comparison operators
+  bool operator==(const TypeDescription_ & other) const
+  {
+    if (this->type_description != other.type_description) {
+      return false;
+    }
+    if (this->referenced_type_descriptions != other.referenced_type_descriptions) {
+      return false;
+    }
+    return true;
+  }
+  bool operator!=(const TypeDescription_ & other) const
+  {
+    return !this->operator==(other);
+  }
+};  // struct TypeDescription_
+
+// alias to use template instance with default allocator
+using TypeDescription =
+  type_description_interfaces::msg::TypeDescription_<std::allocator<void>>;
+
+// constant definitions
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__STRUCT_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__traits.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__traits.hpp
@@ -1,0 +1,150 @@
+// generated from rosidl_generator_cpp/resource/idl__traits.hpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TRAITS_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TRAITS_HPP_
+
+#include <stdint.h>
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include "type_description_interfaces/msg/detail/type_description__struct.hpp"
+#include "rosidl_runtime_cpp/traits.hpp"
+
+// Include directives for member types
+// Member 'type_description'
+// Member 'referenced_type_descriptions'
+#include "type_description_interfaces/msg/detail/individual_type_description__traits.hpp"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+inline void to_flow_style_yaml(
+  const TypeDescription & msg,
+  std::ostream & out)
+{
+  out << "{";
+  // member: type_description
+  {
+    out << "type_description: ";
+    to_flow_style_yaml(msg.type_description, out);
+    out << ", ";
+  }
+
+  // member: referenced_type_descriptions
+  {
+    if (msg.referenced_type_descriptions.size() == 0) {
+      out << "referenced_type_descriptions: []";
+    } else {
+      out << "referenced_type_descriptions: [";
+      size_t pending_items = msg.referenced_type_descriptions.size();
+      for (auto item : msg.referenced_type_descriptions) {
+        to_flow_style_yaml(item, out);
+        if (--pending_items > 0) {
+          out << ", ";
+        }
+      }
+      out << "]";
+    }
+  }
+  out << "}";
+}  // NOLINT(readability/fn_size)
+
+inline void to_block_style_yaml(
+  const TypeDescription & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  // member: type_description
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    out << "type_description:\n";
+    to_block_style_yaml(msg.type_description, out, indentation + 2);
+  }
+
+  // member: referenced_type_descriptions
+  {
+    if (indentation > 0) {
+      out << std::string(indentation, ' ');
+    }
+    if (msg.referenced_type_descriptions.size() == 0) {
+      out << "referenced_type_descriptions: []\n";
+    } else {
+      out << "referenced_type_descriptions:\n";
+      for (auto item : msg.referenced_type_descriptions) {
+        if (indentation > 0) {
+          out << std::string(indentation, ' ');
+        }
+        out << "-\n";
+        to_block_style_yaml(item, out, indentation + 2);
+      }
+    }
+  }
+}  // NOLINT(readability/fn_size)
+
+inline std::string to_yaml(const TypeDescription & msg, bool use_flow_style = false)
+{
+  std::ostringstream out;
+  if (use_flow_style) {
+    to_flow_style_yaml(msg, out);
+  } else {
+    to_block_style_yaml(msg, out);
+  }
+  return out.str();
+}
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+namespace rosidl_generator_traits
+{
+
+[[deprecated("use type_description_interfaces::msg::to_block_style_yaml() instead")]]
+inline void to_yaml(
+  const type_description_interfaces::msg::TypeDescription & msg,
+  std::ostream & out, size_t indentation = 0)
+{
+  type_description_interfaces::msg::to_block_style_yaml(msg, out, indentation);
+}
+
+[[deprecated("use type_description_interfaces::msg::to_yaml() instead")]]
+inline std::string to_yaml(const type_description_interfaces::msg::TypeDescription & msg)
+{
+  return type_description_interfaces::msg::to_yaml(msg);
+}
+
+template<>
+inline const char * data_type<type_description_interfaces::msg::TypeDescription>()
+{
+  return "type_description_interfaces::msg::TypeDescription";
+}
+
+template<>
+inline const char * name<type_description_interfaces::msg::TypeDescription>()
+{
+  return "type_description_interfaces/msg/TypeDescription";
+}
+
+template<>
+struct has_fixed_size<type_description_interfaces::msg::TypeDescription>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct has_bounded_size<type_description_interfaces::msg::TypeDescription>
+  : std::integral_constant<bool, false> {};
+
+template<>
+struct is_message<type_description_interfaces::msg::TypeDescription>
+  : std::true_type {};
+
+}  // namespace rosidl_generator_traits
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TRAITS_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.c
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.c
@@ -1,0 +1,167 @@
+// generated from rosidl_typesupport_introspection_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include <stddef.h>
+#include "type_description_interfaces/msg/detail/type_description__rosidl_typesupport_introspection_c.h"
+#include "type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "type_description_interfaces/msg/detail/type_description__functions.h"
+#include "type_description_interfaces/msg/detail/type_description__struct.h"
+
+
+// Include directives for member types
+// Member `type_description`
+// Member `referenced_type_descriptions`
+#include "type_description_interfaces/msg/individual_type_description.h"
+// Member `type_description`
+// Member `referenced_type_descriptions`
+#include "type_description_interfaces/msg/detail/individual_type_description__rosidl_typesupport_introspection_c.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_init_function(
+  void * message_memory, enum rosidl_runtime_c__message_initialization _init)
+{
+  // TODO(karsten1987): initializers are not yet implemented for typesupport c
+  // see https://github.com/ros2/ros2/issues/397
+  (void) _init;
+  type_description_interfaces__msg__TypeDescription__init(message_memory);
+}
+
+void type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_fini_function(void * message_memory)
+{
+  type_description_interfaces__msg__TypeDescription__fini(message_memory);
+}
+
+size_t type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__size_function__TypeDescription__referenced_type_descriptions(
+  const void * untyped_member)
+{
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * member =
+    (const type_description_interfaces__msg__IndividualTypeDescription__Sequence *)(untyped_member);
+  return member->size;
+}
+
+const void * type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_const_function__TypeDescription__referenced_type_descriptions(
+  const void * untyped_member, size_t index)
+{
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * member =
+    (const type_description_interfaces__msg__IndividualTypeDescription__Sequence *)(untyped_member);
+  return &member->data[index];
+}
+
+void * type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_function__TypeDescription__referenced_type_descriptions(
+  void * untyped_member, size_t index)
+{
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * member =
+    (type_description_interfaces__msg__IndividualTypeDescription__Sequence *)(untyped_member);
+  return &member->data[index];
+}
+
+void type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__fetch_function__TypeDescription__referenced_type_descriptions(
+  const void * untyped_member, size_t index, void * untyped_value)
+{
+  const type_description_interfaces__msg__IndividualTypeDescription * item =
+    ((const type_description_interfaces__msg__IndividualTypeDescription *)
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_const_function__TypeDescription__referenced_type_descriptions(untyped_member, index));
+  type_description_interfaces__msg__IndividualTypeDescription * value =
+    (type_description_interfaces__msg__IndividualTypeDescription *)(untyped_value);
+  *value = *item;
+}
+
+void type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__assign_function__TypeDescription__referenced_type_descriptions(
+  void * untyped_member, size_t index, const void * untyped_value)
+{
+  type_description_interfaces__msg__IndividualTypeDescription * item =
+    ((type_description_interfaces__msg__IndividualTypeDescription *)
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_function__TypeDescription__referenced_type_descriptions(untyped_member, index));
+  const type_description_interfaces__msg__IndividualTypeDescription * value =
+    (const type_description_interfaces__msg__IndividualTypeDescription *)(untyped_value);
+  *item = *value;
+}
+
+bool type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__resize_function__TypeDescription__referenced_type_descriptions(
+  void * untyped_member, size_t size)
+{
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * member =
+    (type_description_interfaces__msg__IndividualTypeDescription__Sequence *)(untyped_member);
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(member);
+  return type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(member, size);
+}
+
+static rosidl_typesupport_introspection_c__MessageMember type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_member_array[2] = {
+  {
+    "type_description",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message (initialized later)
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__TypeDescription, type_description),  // bytes offset in struct
+    NULL,  // default value
+    NULL,  // size() function pointer
+    NULL,  // get_const(index) function pointer
+    NULL,  // get(index) function pointer
+    NULL,  // fetch(index, &value) function pointer
+    NULL,  // assign(index, value) function pointer
+    NULL  // resize(index) function pointer
+  },
+  {
+    "referenced_type_descriptions",  // name
+    rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    NULL,  // members of sub message (initialized later)
+    true,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces__msg__TypeDescription, referenced_type_descriptions),  // bytes offset in struct
+    NULL,  // default value
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__size_function__TypeDescription__referenced_type_descriptions,  // size() function pointer
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_const_function__TypeDescription__referenced_type_descriptions,  // get_const(index) function pointer
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__get_function__TypeDescription__referenced_type_descriptions,  // get(index) function pointer
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__fetch_function__TypeDescription__referenced_type_descriptions,  // fetch(index, &value) function pointer
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__assign_function__TypeDescription__referenced_type_descriptions,  // assign(index, value) function pointer
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__resize_function__TypeDescription__referenced_type_descriptions  // resize(index) function pointer
+  }
+};
+
+static const rosidl_typesupport_introspection_c__MessageMembers type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_members = {
+  "type_description_interfaces__msg",  // message namespace
+  "TypeDescription",  // message name
+  2,  // number of fields
+  sizeof(type_description_interfaces__msg__TypeDescription),
+  type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_member_array,  // message members
+  type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_init_function,  // function to initialize message memory (memory has to be allocated)
+  type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_fini_function  // function to terminate message instance (will not free memory)
+};
+
+// this is not const since it must be initialized on first access
+// since C does not allow non-integral compile-time constants
+static rosidl_message_type_support_t type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_type_support_handle = {
+  0,
+  &type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_members,
+  get_message_typesupport_handle_function,
+};
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, TypeDescription)() {
+  type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_member_array[0].members_ =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, IndividualTypeDescription)();
+  type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_member_array[1].members_ =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_c, type_description_interfaces, msg, IndividualTypeDescription)();
+  if (!type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_type_support_handle.typesupport_identifier) {
+    type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_type_support_handle.typesupport_identifier =
+      rosidl_typesupport_introspection_c__identifier;
+  }
+  return &type_description_interfaces__msg__TypeDescription__rosidl_typesupport_introspection_c__TypeDescription_message_type_support_handle;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.cpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.cpp
@@ -1,0 +1,171 @@
+// generated from rosidl_typesupport_introspection_cpp/resource/idl__type_support.cpp.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include "array"
+#include "cstddef"
+#include "string"
+#include "vector"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/type_description__struct.hpp"
+#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_type_support_decl.hpp"
+#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+
+namespace type_description_interfaces
+{
+
+namespace msg
+{
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+void TypeDescription_init_function(
+  void * message_memory, rosidl_runtime_cpp::MessageInitialization _init)
+{
+  new (message_memory) type_description_interfaces::msg::TypeDescription(_init);
+}
+
+void TypeDescription_fini_function(void * message_memory)
+{
+  auto typed_message = static_cast<type_description_interfaces::msg::TypeDescription *>(message_memory);
+  typed_message->~TypeDescription();
+}
+
+size_t size_function__TypeDescription__referenced_type_descriptions(const void * untyped_member)
+{
+  const auto * member = reinterpret_cast<const std::vector<type_description_interfaces::msg::IndividualTypeDescription> *>(untyped_member);
+  return member->size();
+}
+
+const void * get_const_function__TypeDescription__referenced_type_descriptions(const void * untyped_member, size_t index)
+{
+  const auto & member =
+    *reinterpret_cast<const std::vector<type_description_interfaces::msg::IndividualTypeDescription> *>(untyped_member);
+  return &member[index];
+}
+
+void * get_function__TypeDescription__referenced_type_descriptions(void * untyped_member, size_t index)
+{
+  auto & member =
+    *reinterpret_cast<std::vector<type_description_interfaces::msg::IndividualTypeDescription> *>(untyped_member);
+  return &member[index];
+}
+
+void fetch_function__TypeDescription__referenced_type_descriptions(
+  const void * untyped_member, size_t index, void * untyped_value)
+{
+  const auto & item = *reinterpret_cast<const type_description_interfaces::msg::IndividualTypeDescription *>(
+    get_const_function__TypeDescription__referenced_type_descriptions(untyped_member, index));
+  auto & value = *reinterpret_cast<type_description_interfaces::msg::IndividualTypeDescription *>(untyped_value);
+  value = item;
+}
+
+void assign_function__TypeDescription__referenced_type_descriptions(
+  void * untyped_member, size_t index, const void * untyped_value)
+{
+  auto & item = *reinterpret_cast<type_description_interfaces::msg::IndividualTypeDescription *>(
+    get_function__TypeDescription__referenced_type_descriptions(untyped_member, index));
+  const auto & value = *reinterpret_cast<const type_description_interfaces::msg::IndividualTypeDescription *>(untyped_value);
+  item = value;
+}
+
+void resize_function__TypeDescription__referenced_type_descriptions(void * untyped_member, size_t size)
+{
+  auto * member =
+    reinterpret_cast<std::vector<type_description_interfaces::msg::IndividualTypeDescription> *>(untyped_member);
+  member->resize(size);
+}
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMember TypeDescription_message_member_array[2] = {
+  {
+    "type_description",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<type_description_interfaces::msg::IndividualTypeDescription>(),  // members of sub message
+    false,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::TypeDescription, type_description),  // bytes offset in struct
+    nullptr,  // default value
+    nullptr,  // size() function pointer
+    nullptr,  // get_const(index) function pointer
+    nullptr,  // get(index) function pointer
+    nullptr,  // fetch(index, &value) function pointer
+    nullptr,  // assign(index, value) function pointer
+    nullptr  // resize(index) function pointer
+  },
+  {
+    "referenced_type_descriptions",  // name
+    ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE,  // type
+    0,  // upper bound of string
+    ::rosidl_typesupport_introspection_cpp::get_message_type_support_handle<type_description_interfaces::msg::IndividualTypeDescription>(),  // members of sub message
+    true,  // is array
+    0,  // array size
+    false,  // is upper bound
+    offsetof(type_description_interfaces::msg::TypeDescription, referenced_type_descriptions),  // bytes offset in struct
+    nullptr,  // default value
+    size_function__TypeDescription__referenced_type_descriptions,  // size() function pointer
+    get_const_function__TypeDescription__referenced_type_descriptions,  // get_const(index) function pointer
+    get_function__TypeDescription__referenced_type_descriptions,  // get(index) function pointer
+    fetch_function__TypeDescription__referenced_type_descriptions,  // fetch(index, &value) function pointer
+    assign_function__TypeDescription__referenced_type_descriptions,  // assign(index, value) function pointer
+    resize_function__TypeDescription__referenced_type_descriptions  // resize(index) function pointer
+  }
+};
+
+static const ::rosidl_typesupport_introspection_cpp::MessageMembers TypeDescription_message_members = {
+  "type_description_interfaces::msg",  // message namespace
+  "TypeDescription",  // message name
+  2,  // number of fields
+  sizeof(type_description_interfaces::msg::TypeDescription),
+  TypeDescription_message_member_array,  // message members
+  TypeDescription_init_function,  // function to initialize message memory (memory has to be allocated)
+  TypeDescription_fini_function  // function to terminate message instance (will not free memory)
+};
+
+static const rosidl_message_type_support_t TypeDescription_message_type_support_handle = {
+  ::rosidl_typesupport_introspection_cpp::typesupport_identifier,
+  &TypeDescription_message_members,
+  get_message_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+}  // namespace msg
+
+}  // namespace type_description_interfaces
+
+
+namespace rosidl_typesupport_introspection_cpp
+{
+
+template<>
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+get_message_type_support_handle<type_description_interfaces::msg::TypeDescription>()
+{
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::TypeDescription_message_type_support_handle;
+}
+
+}  // namespace rosidl_typesupport_introspection_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_PUBLIC
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_introspection_cpp, type_description_interfaces, msg, TypeDescription)() {
+  return &::type_description_interfaces::msg::rosidl_typesupport_introspection_cpp::TypeDescription_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/detail/type_description__type_support.h
@@ -1,0 +1,33 @@
+// generated from rosidl_generator_c/resource/idl__type_support.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TYPE_SUPPORT_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TYPE_SUPPORT_H_
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "type_description_interfaces/msg/rosidl_generator_c__visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rosidl_runtime_c/message_type_support_struct.h"
+
+// Forward declare the get type support functions for this type.
+ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+  rosidl_typesupport_c,
+  type_description_interfaces,
+  msg,
+  TypeDescription
+)();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__DETAIL__TYPE_DESCRIPTION__TYPE_SUPPORT_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/field.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/field.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_H_
+
+#include "type_description_interfaces/msg/detail/field__struct.h"
+#include "type_description_interfaces/msg/detail/field__functions.h"
+#include "type_description_interfaces/msg/detail/field__type_support.h"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/field.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/field.hpp
@@ -1,0 +1,11 @@
+// generated from rosidl_generator_cpp/resource/idl.hpp.em
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_HPP_
+
+#include "type_description_interfaces/msg/detail/field__struct.hpp"
+#include "type_description_interfaces/msg/detail/field__builder.hpp"
+#include "type_description_interfaces/msg/detail/field__traits.hpp"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/field_type.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/field_type.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_H_
+
+#include "type_description_interfaces/msg/detail/field_type__struct.h"
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+#include "type_description_interfaces/msg/detail/field_type__type_support.h"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/field_type.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/field_type.hpp
@@ -1,0 +1,11 @@
+// generated from rosidl_generator_cpp/resource/idl.hpp.em
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_HPP_
+
+#include "type_description_interfaces/msg/detail/field_type__struct.hpp"
+#include "type_description_interfaces/msg/detail/field_type__builder.hpp"
+#include "type_description_interfaces/msg/detail/field_type__traits.hpp"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__FIELD_TYPE_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/individual_type_description.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/individual_type_description.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_H_
+
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__type_support.h"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/individual_type_description.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/individual_type_description.hpp
@@ -1,0 +1,11 @@
+// generated from rosidl_generator_cpp/resource/idl.hpp.em
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_HPP_
+
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.hpp"
+#include "type_description_interfaces/msg/detail/individual_type_description__builder.hpp"
+#include "type_description_interfaces/msg/detail/individual_type_description__traits.hpp"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__INDIVIDUAL_TYPE_DESCRIPTION_HPP_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_generator_c__visibility_control.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_generator_c__visibility_control.h
@@ -1,0 +1,42 @@
+// generated from rosidl_generator_c/resource/rosidl_generator_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_GENERATOR_C_EXPORT_type_description_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_GENERATOR_C_IMPORT_type_description_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_GENERATOR_C_EXPORT_type_description_interfaces __declspec(dllexport)
+    #define ROSIDL_GENERATOR_C_IMPORT_type_description_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_GENERATOR_C_BUILDING_DLL_type_description_interfaces
+    #define ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces ROSIDL_GENERATOR_C_EXPORT_type_description_interfaces
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces ROSIDL_GENERATOR_C_IMPORT_type_description_interfaces
+  #endif
+#else
+  #define ROSIDL_GENERATOR_C_EXPORT_type_description_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_GENERATOR_C_IMPORT_type_description_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_GENERATOR_C_PUBLIC_type_description_interfaces
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_GENERATOR_C__VISIBILITY_CONTROL_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_fastrtps_c__visibility_control.h
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_fastrtps_c/resource/rosidl_typesupport_fastrtps_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_C__VISIBILITY_CONTROL_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_C__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_EXPORT_type_description_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_type_description_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_EXPORT_type_description_interfaces __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_type_description_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_C_BUILDING_DLL_type_description_interfaces
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_FASTRTPS_C_EXPORT_type_description_interfaces
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_type_description_interfaces
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_FASTRTPS_C_EXPORT_type_description_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_FASTRTPS_C_IMPORT_type_description_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_C_PUBLIC_type_description_interfaces
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_C__VISIBILITY_CONTROL_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_fastrtps_cpp__visibility_control.h
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_fastrtps_cpp/resource/rosidl_typesupport_fastrtps_cpp__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_CPP__VISIBILITY_CONTROL_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_CPP__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_type_description_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_IMPORT_type_description_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_type_description_interfaces __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_IMPORT_type_description_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_CPP_BUILDING_DLL_type_description_interfaces
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_type_description_interfaces
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_FASTRTPS_CPP_IMPORT_type_description_interfaces
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_EXPORT_type_description_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_IMPORT_type_description_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_FASTRTPS_CPP_PUBLIC_type_description_interfaces
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_FASTRTPS_CPP__VISIBILITY_CONTROL_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/rosidl_typesupport_introspection_c__visibility_control.h
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_introspection_c/resource/rosidl_typesupport_introspection_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_type_description_interfaces __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_type_description_interfaces __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_INTROSPECTION_C_BUILDING_DLL_type_description_interfaces
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_type_description_interfaces
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_EXPORT_type_description_interfaces __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_IMPORT_type_description_interfaces
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_INTROSPECTION_C_PUBLIC_type_description_interfaces
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__ROSIDL_TYPESUPPORT_INTROSPECTION_C__VISIBILITY_CONTROL_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/type_description.h
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/type_description.h
@@ -1,0 +1,12 @@
+// generated from rosidl_generator_c/resource/idl.h.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_H_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_H_
+
+#include "type_description_interfaces/msg/detail/type_description__struct.h"
+#include "type_description_interfaces/msg/detail/type_description__functions.h"
+#include "type_description_interfaces/msg/detail/type_description__type_support.h"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_H_

--- a/type_description_interfaces_static/include/type_description_interfaces/msg/type_description.hpp
+++ b/type_description_interfaces_static/include/type_description_interfaces/msg/type_description.hpp
@@ -1,0 +1,11 @@
+// generated from rosidl_generator_cpp/resource/idl.hpp.em
+// generated code does not contain a copyright notice
+
+#ifndef TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_HPP_
+#define TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_HPP_
+
+#include "type_description_interfaces/msg/detail/type_description__struct.hpp"
+#include "type_description_interfaces/msg/detail/type_description__builder.hpp"
+#include "type_description_interfaces/msg/detail/type_description__traits.hpp"
+
+#endif  // TYPE_DESCRIPTION_INTERFACES__MSG__TYPE_DESCRIPTION_HPP_

--- a/type_description_interfaces_static/package.xml
+++ b/type_description_interfaces_static/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>type_description_interfaces_static</name>
+  <version>1.3.1</version>
+  <description>Static instantiation of the type_description_interfaces package.</description>
+
+  <maintainer email="william@openrobotics.org">William Woodall</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rosidl_runtime_c</depend>
+  <depend>rosidl_runtime_cpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/type_description_interfaces_static/src/field__functions.c
+++ b/type_description_interfaces_static/src/field__functions.c
@@ -1,0 +1,292 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/field__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `name`
+// Member `default_value`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `type`
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+
+bool
+type_description_interfaces__msg__Field__init(type_description_interfaces__msg__Field * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__init(&msg->name)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__init(&msg->type)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__init(&msg->default_value)) {
+    type_description_interfaces__msg__Field__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__Field__fini(type_description_interfaces__msg__Field * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // name
+  rosidl_runtime_c__String__fini(&msg->name);
+  // type
+  type_description_interfaces__msg__FieldType__fini(&msg->type);
+  // default_value
+  rosidl_runtime_c__String__fini(&msg->default_value);
+}
+
+bool
+type_description_interfaces__msg__Field__are_equal(const type_description_interfaces__msg__Field * lhs, const type_description_interfaces__msg__Field * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->name), &(rhs->name)))
+  {
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__are_equal(
+      &(lhs->type), &(rhs->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->default_value), &(rhs->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__Field__copy(
+  const type_description_interfaces__msg__Field * input,
+  type_description_interfaces__msg__Field * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->name), &(output->name)))
+  {
+    return false;
+  }
+  // type
+  if (!type_description_interfaces__msg__FieldType__copy(
+      &(input->type), &(output->type)))
+  {
+    return false;
+  }
+  // default_value
+  if (!rosidl_runtime_c__String__copy(
+      &(input->default_value), &(output->default_value)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__Field *
+type_description_interfaces__msg__Field__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field * msg = (type_description_interfaces__msg__Field *)allocator.allocate(sizeof(type_description_interfaces__msg__Field), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__Field));
+  bool success = type_description_interfaces__msg__Field__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__Field__destroy(type_description_interfaces__msg__Field * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__Field__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__Field__Sequence__init(type_description_interfaces__msg__Field__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__Field *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__Field), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__Field__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__Field__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__Field__Sequence__fini(type_description_interfaces__msg__Field__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__Field__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__Field__Sequence *
+type_description_interfaces__msg__Field__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__Field__Sequence * array = (type_description_interfaces__msg__Field__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__Field__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__Field__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__Field__Sequence__destroy(type_description_interfaces__msg__Field__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__Field__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__Field__Sequence__are_equal(const type_description_interfaces__msg__Field__Sequence * lhs, const type_description_interfaces__msg__Field__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__Field__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__Field__Sequence__copy(
+  const type_description_interfaces__msg__Field__Sequence * input,
+  type_description_interfaces__msg__Field__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__Field);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__Field * data =
+      (type_description_interfaces__msg__Field *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__Field__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__Field__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__Field__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/src/field__type_support.c
+++ b/type_description_interfaces_static/src/field__type_support.c
@@ -1,0 +1,19 @@
+// generated from rosidl_generator_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/Field.idl
+// generated code does not contain a copyright notice
+
+#include <string.h>
+
+#include "type_description_interfaces/msg/detail/field__functions.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/field__type_support.h"
+#include "type_description_interfaces/msg/detail/field__struct.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/src/field_type__functions.c
+++ b/type_description_interfaces_static/src/field_type__functions.c
@@ -1,0 +1,276 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `nested_type_name`
+#include "rosidl_runtime_c/string_functions.h"
+
+bool
+type_description_interfaces__msg__FieldType__init(type_description_interfaces__msg__FieldType * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_id
+  msg->type_id = 0;
+  // capacity
+  // string_capacity
+  // nested_type_name
+  if (!rosidl_runtime_c__String__init(&msg->nested_type_name)) {
+    type_description_interfaces__msg__FieldType__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__FieldType__fini(type_description_interfaces__msg__FieldType * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_id
+  // capacity
+  // string_capacity
+  // nested_type_name
+  rosidl_runtime_c__String__fini(&msg->nested_type_name);
+}
+
+bool
+type_description_interfaces__msg__FieldType__are_equal(const type_description_interfaces__msg__FieldType * lhs, const type_description_interfaces__msg__FieldType * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_id
+  if (lhs->type_id != rhs->type_id) {
+    return false;
+  }
+  // capacity
+  if (lhs->capacity != rhs->capacity) {
+    return false;
+  }
+  // string_capacity
+  if (lhs->string_capacity != rhs->string_capacity) {
+    return false;
+  }
+  // nested_type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->nested_type_name), &(rhs->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__FieldType__copy(
+  const type_description_interfaces__msg__FieldType * input,
+  type_description_interfaces__msg__FieldType * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_id
+  output->type_id = input->type_id;
+  // capacity
+  output->capacity = input->capacity;
+  // string_capacity
+  output->string_capacity = input->string_capacity;
+  // nested_type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->nested_type_name), &(output->nested_type_name)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__FieldType *
+type_description_interfaces__msg__FieldType__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType * msg = (type_description_interfaces__msg__FieldType *)allocator.allocate(sizeof(type_description_interfaces__msg__FieldType), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__FieldType));
+  bool success = type_description_interfaces__msg__FieldType__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__FieldType__destroy(type_description_interfaces__msg__FieldType * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__FieldType__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__init(type_description_interfaces__msg__FieldType__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__FieldType *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__FieldType), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__FieldType__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__FieldType__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__FieldType__Sequence__fini(type_description_interfaces__msg__FieldType__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__FieldType__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__FieldType__Sequence *
+type_description_interfaces__msg__FieldType__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__FieldType__Sequence * array = (type_description_interfaces__msg__FieldType__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__FieldType__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__FieldType__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__FieldType__Sequence__destroy(type_description_interfaces__msg__FieldType__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__FieldType__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__are_equal(const type_description_interfaces__msg__FieldType__Sequence * lhs, const type_description_interfaces__msg__FieldType__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__FieldType__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__FieldType__Sequence__copy(
+  const type_description_interfaces__msg__FieldType__Sequence * input,
+  type_description_interfaces__msg__FieldType__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__FieldType);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__FieldType * data =
+      (type_description_interfaces__msg__FieldType *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__FieldType__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__FieldType__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__FieldType__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/src/field_type__type_support.c
+++ b/type_description_interfaces_static/src/field_type__type_support.c
@@ -1,0 +1,19 @@
+// generated from rosidl_generator_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/FieldType.idl
+// generated code does not contain a copyright notice
+
+#include <string.h>
+
+#include "type_description_interfaces/msg/detail/field_type__struct.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/field_type__type_support.h"
+#include "type_description_interfaces/msg/detail/field_type__functions.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/src/individual_type_description__functions.c
+++ b/type_description_interfaces_static/src/individual_type_description__functions.c
@@ -1,0 +1,272 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_name`
+#include "rosidl_runtime_c/string_functions.h"
+// Member `fields`
+#include "type_description_interfaces/msg/detail/field__functions.h"
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__init(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__init(&msg->type_name)) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__init(&msg->fields, 0)) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__fini(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_name
+  rosidl_runtime_c__String__fini(&msg->type_name);
+  // fields
+  type_description_interfaces__msg__Field__Sequence__fini(&msg->fields);
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__are_equal(const type_description_interfaces__msg__IndividualTypeDescription * lhs, const type_description_interfaces__msg__IndividualTypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__are_equal(
+      &(lhs->type_name), &(rhs->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__are_equal(
+      &(lhs->fields), &(rhs->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription * input,
+  type_description_interfaces__msg__IndividualTypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_name
+  if (!rosidl_runtime_c__String__copy(
+      &(input->type_name), &(output->type_name)))
+  {
+    return false;
+  }
+  // fields
+  if (!type_description_interfaces__msg__Field__Sequence__copy(
+      &(input->fields), &(output->fields)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__IndividualTypeDescription *
+type_description_interfaces__msg__IndividualTypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription * msg = (type_description_interfaces__msg__IndividualTypeDescription *)allocator.allocate(sizeof(type_description_interfaces__msg__IndividualTypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__IndividualTypeDescription));
+  bool success = type_description_interfaces__msg__IndividualTypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__destroy(type_description_interfaces__msg__IndividualTypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__IndividualTypeDescription *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__IndividualTypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__IndividualTypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__IndividualTypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__IndividualTypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__IndividualTypeDescription__Sequence *
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * array = (type_description_interfaces__msg__IndividualTypeDescription__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__IndividualTypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(type_description_interfaces__msg__IndividualTypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(const type_description_interfaces__msg__IndividualTypeDescription__Sequence * lhs, const type_description_interfaces__msg__IndividualTypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * input,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__IndividualTypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__IndividualTypeDescription * data =
+      (type_description_interfaces__msg__IndividualTypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__IndividualTypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__IndividualTypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/src/individual_type_description__type_support.c
+++ b/type_description_interfaces_static/src/individual_type_description__type_support.c
@@ -1,0 +1,19 @@
+// generated from rosidl_generator_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/IndividualTypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include <string.h>
+
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__struct.h"
+#include "type_description_interfaces/msg/detail/individual_type_description__type_support.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_static/src/type_description__functions.c
+++ b/type_description_interfaces_static/src/type_description__functions.c
@@ -1,0 +1,271 @@
+// generated from rosidl_generator_c/resource/idl__functions.c.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+#include "type_description_interfaces/msg/detail/type_description__functions.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+
+
+// Include directives for member types
+// Member `type_description`
+// Member `referenced_type_descriptions`
+#include "type_description_interfaces/msg/detail/individual_type_description__functions.h"
+
+bool
+type_description_interfaces__msg__TypeDescription__init(type_description_interfaces__msg__TypeDescription * msg)
+{
+  if (!msg) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__init(&msg->type_description)) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__init(&msg->referenced_type_descriptions, 0)) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+    return false;
+  }
+  return true;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__fini(type_description_interfaces__msg__TypeDescription * msg)
+{
+  if (!msg) {
+    return;
+  }
+  // type_description
+  type_description_interfaces__msg__IndividualTypeDescription__fini(&msg->type_description);
+  // referenced_type_descriptions
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__fini(&msg->referenced_type_descriptions);
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__are_equal(const type_description_interfaces__msg__TypeDescription * lhs, const type_description_interfaces__msg__TypeDescription * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &(lhs->type_description), &(rhs->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(
+      &(lhs->referenced_type_descriptions), &(rhs->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__copy(
+  const type_description_interfaces__msg__TypeDescription * input,
+  type_description_interfaces__msg__TypeDescription * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  // type_description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+      &(input->type_description), &(output->type_description)))
+  {
+    return false;
+  }
+  // referenced_type_descriptions
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+      &(input->referenced_type_descriptions), &(output->referenced_type_descriptions)))
+  {
+    return false;
+  }
+  return true;
+}
+
+type_description_interfaces__msg__TypeDescription *
+type_description_interfaces__msg__TypeDescription__create()
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription * msg = (type_description_interfaces__msg__TypeDescription *)allocator.allocate(sizeof(type_description_interfaces__msg__TypeDescription), allocator.state);
+  if (!msg) {
+    return NULL;
+  }
+  memset(msg, 0, sizeof(type_description_interfaces__msg__TypeDescription));
+  bool success = type_description_interfaces__msg__TypeDescription__init(msg);
+  if (!success) {
+    allocator.deallocate(msg, allocator.state);
+    return NULL;
+  }
+  return msg;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__destroy(type_description_interfaces__msg__TypeDescription * msg)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (msg) {
+    type_description_interfaces__msg__TypeDescription__fini(msg);
+  }
+  allocator.deallocate(msg, allocator.state);
+}
+
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__init(type_description_interfaces__msg__TypeDescription__Sequence * array, size_t size)
+{
+  if (!array) {
+    return false;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription * data = NULL;
+
+  if (size) {
+    data = (type_description_interfaces__msg__TypeDescription *)allocator.zero_allocate(size, sizeof(type_description_interfaces__msg__TypeDescription), allocator.state);
+    if (!data) {
+      return false;
+    }
+    // initialize all array elements
+    size_t i;
+    for (i = 0; i < size; ++i) {
+      bool success = type_description_interfaces__msg__TypeDescription__init(&data[i]);
+      if (!success) {
+        break;
+      }
+    }
+    if (i < size) {
+      // if initialization failed finalize the already initialized array elements
+      for (; i > 0; --i) {
+        type_description_interfaces__msg__TypeDescription__fini(&data[i - 1]);
+      }
+      allocator.deallocate(data, allocator.state);
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__Sequence__fini(type_description_interfaces__msg__TypeDescription__Sequence * array)
+{
+  if (!array) {
+    return;
+  }
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    for (size_t i = 0; i < array->capacity; ++i) {
+      type_description_interfaces__msg__TypeDescription__fini(&array->data[i]);
+    }
+    allocator.deallocate(array->data, allocator.state);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+type_description_interfaces__msg__TypeDescription__Sequence *
+type_description_interfaces__msg__TypeDescription__Sequence__create(size_t size)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  type_description_interfaces__msg__TypeDescription__Sequence * array = (type_description_interfaces__msg__TypeDescription__Sequence *)allocator.allocate(sizeof(type_description_interfaces__msg__TypeDescription__Sequence), allocator.state);
+  if (!array) {
+    return NULL;
+  }
+  bool success = type_description_interfaces__msg__TypeDescription__Sequence__init(array, size);
+  if (!success) {
+    allocator.deallocate(array, allocator.state);
+    return NULL;
+  }
+  return array;
+}
+
+void
+type_description_interfaces__msg__TypeDescription__Sequence__destroy(type_description_interfaces__msg__TypeDescription__Sequence * array)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (array) {
+    type_description_interfaces__msg__TypeDescription__Sequence__fini(array);
+  }
+  allocator.deallocate(array, allocator.state);
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__are_equal(const type_description_interfaces__msg__TypeDescription__Sequence * lhs, const type_description_interfaces__msg__TypeDescription__Sequence * rhs)
+{
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs->size != rhs->size) {
+    return false;
+  }
+  for (size_t i = 0; i < lhs->size; ++i) {
+    if (!type_description_interfaces__msg__TypeDescription__are_equal(&(lhs->data[i]), &(rhs->data[i]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool
+type_description_interfaces__msg__TypeDescription__Sequence__copy(
+  const type_description_interfaces__msg__TypeDescription__Sequence * input,
+  type_description_interfaces__msg__TypeDescription__Sequence * output)
+{
+  if (!input || !output) {
+    return false;
+  }
+  if (output->capacity < input->size) {
+    const size_t allocation_size =
+      input->size * sizeof(type_description_interfaces__msg__TypeDescription);
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    type_description_interfaces__msg__TypeDescription * data =
+      (type_description_interfaces__msg__TypeDescription *)allocator.reallocate(
+      output->data, allocation_size, allocator.state);
+    if (!data) {
+      return false;
+    }
+    // If reallocation succeeded, memory may or may not have been moved
+    // to fulfill the allocation request, invalidating output->data.
+    output->data = data;
+    for (size_t i = output->capacity; i < input->size; ++i) {
+      if (!type_description_interfaces__msg__TypeDescription__init(&output->data[i])) {
+        // If initialization of any new item fails, roll back
+        // all previously initialized items. Existing items
+        // in output are to be left unmodified.
+        for (; i-- > output->capacity; ) {
+          type_description_interfaces__msg__TypeDescription__fini(&output->data[i]);
+        }
+        return false;
+      }
+    }
+    output->capacity = input->size;
+  }
+  output->size = input->size;
+  for (size_t i = 0; i < input->size; ++i) {
+    if (!type_description_interfaces__msg__TypeDescription__copy(
+        &(input->data[i]), &(output->data[i])))
+    {
+      return false;
+    }
+  }
+  return true;
+}

--- a/type_description_interfaces_static/src/type_description__type_support.c
+++ b/type_description_interfaces_static/src/type_description__type_support.c
@@ -1,0 +1,19 @@
+// generated from rosidl_generator_c/resource/idl__type_support.c.em
+// with input from type_description_interfaces:msg/TypeDescription.idl
+// generated code does not contain a copyright notice
+
+#include <string.h>
+
+#include "type_description_interfaces/msg/detail/type_description__type_support.h"
+#include "type_description_interfaces/msg/detail/type_description__functions.h"
+#include "rosidl_typesupport_interface/macros.h"
+#include "type_description_interfaces/msg/detail/type_description__struct.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/type_description_interfaces_utils/CMakeLists.txt
+++ b/type_description_interfaces_utils/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(type_description_interfaces REQUIRED)
+find_package(type_description_interfaces_static REQUIRED)
 
 ###########
 ## Build ##
@@ -31,7 +31,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rcutils::rcutils
-  ${type_description_interfaces_TARGETS}
+  type_description_interfaces_static::type_description_interfaces_static
 )
 
 #############
@@ -61,8 +61,8 @@ install(DIRECTORY include/
 ament_export_targets(${PROJECT_NAME}-export HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   ament_cmake_ros
-  type_description_interfaces
   rcutils
+  type_description_interfaces_static
 )
 
 ament_package()

--- a/type_description_interfaces_utils/CMakeLists.txt
+++ b/type_description_interfaces_utils/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16)
+project(type_description_interfaces_utils)
+
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+find_package(ament_cmake_ros REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(type_description_interfaces REQUIRED)
+
+###########
+## Build ##
+###########
+add_library(${PROJECT_NAME} "src/utils.c")
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcutils::rcutils
+  ${type_description_interfaces_TARGETS}
+)
+
+#############
+## Testing ##
+#############
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
+endif()
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-export
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+ament_export_targets(${PROJECT_NAME}-export HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  ament_cmake_ros
+  type_description_interfaces
+  rcutils
+)
+
+ament_package()

--- a/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
+++ b/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
@@ -1,0 +1,642 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** type_description_interfaces_utils: Utilities for manipulating type_description_interfaces
+ *                                     C message structs
+ */
+
+// NOTE(methylDragon): I made it so that every instance of a non-message struct (e.g. hash map)
+//                     borrows, whereas the message structs copy.
+//                     So lifetime should be managed by the message structs.
+
+#ifndef TYPE_DESCRIPTION_INTERFACES_UTILS__UTILS_H_
+#define TYPE_DESCRIPTION_INTERFACES_UTILS__UTILS_H_
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <type_description_interfaces_utils/visibility_control.h>
+
+#include <rcutils/types/rcutils_ret.h>
+#include <rcutils/types/hash_map.h>
+
+#include <type_description_interfaces/msg/field.h>
+#include <type_description_interfaces/msg/individual_type_description.h>
+#include <type_description_interfaces/msg/type_description.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+static const uint8_t TYPE_DESCRIPTION_INTERFACES_UTILS_SEQUENCE_TYPE_ID_DELIMITER = 48;
+
+
+// =================================================================================================
+// GET BY NAME
+// =================================================================================================
+
+/// Get the first Field, matching by name.
+/**
+ * NOTE: The `field` output arg must be passed in pointing to `NULL`.
+ *       It will remain pointing to `NULL` if no matching `Field` is found.
+ *
+ * Ownership:
+ * - The output `Field` borrows the `fields` arg's `Field` element. It is not authorized to delete
+ *   its value and cannot outlive the owner it borrows from.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] fields array of fields to search through
+ * \param[in] name field name of the field to look for
+ * \param[out] field the first field with field name that matches the name arg.
+ *                   Must point to `NULL`, outputs pointing to `NULL` if not found.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_FOUND if no `Field` with a matching name is found, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_find_field(
+  const type_description_interfaces__msg__Field__Sequence * fields,
+  const char * name,
+  type_description_interfaces__msg__Field ** field);
+
+/// Get the first referenced IndividualTypeDescription, matching by type name.
+/**
+ * NOTE: The `referenced_type` output arg must be passed in pointing `NULL`.
+ *       It will remain pointing to `NULL` if no matching `IndividualTypeDescription` is found.
+ *
+ * Ownership:
+ * - The output `IndividualTypeDescription` borrows the `referenced_types` arg's
+ *   `IndividualTypeDescription` element. It is not authorized to delete its value and cannot
+ *   outlive the `referenced_types` it borrows from.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] referenced_types array of referenced individual type descriptions to search through
+ * \param[in] type_name name of the referenced referenced individual type description to look for
+ * \param[out] referenced_type the first individual type description with type name that matches the
+ *                             type_name arg. Must point to `NULL`, outputs pointing to `NULL` if
+ *                             not found.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_FOUND if no `IndividualTypeDescription` with matching name is found, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_find_referenced_type_description(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types,
+  const char * type_name,
+  type_description_interfaces__msg__IndividualTypeDescription ** referenced_type);
+
+
+// =================================================================================================
+// HASH MAPS
+// =================================================================================================
+
+/// Construct a hash map of an `IndividualTypeDescription`'s `Field` objects, keyed by field name.
+/**
+ * NOTE: The `hash_map` output arg must be passed in pointing to `NULL`.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `rcutils_hash_map_t` and must free it and its
+ *   elements, but NOT finalize its values.
+ * - The output `rcutils_hash_map_t` has values that borrows the `individual_description` arg's
+ *   `Field` objects. It is not authorized to delete its values and it cannot outlive the owner it
+ *   borrows from.
+ *   - Finalizing the `rcutils_hash_map_t` should not result in the map's values getting finalized.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] individual_description the individual type description to get the fields from
+ * \param[in] allocator the allocator to use through out the lifetime of the hash_map
+ * \param[out] hash_map `rcutils_hash_map_t` to be initialized, containing `Field` objects keyed by
+ *                      their field names. Must point to `NULL`, outputs pointing to `NULL`
+ *                      if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_get_field_map(
+  const type_description_interfaces__msg__IndividualTypeDescription * individual_description,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** hash_map);
+
+/// Construct a hash map of an `IndividualTypeDescription__Sequence`'s `IndividualTypeDescription`
+/// objects, keyed by type name.
+/**
+ * NOTE: The `hash_map` output arg must be passed in pointing to `NULL`.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `rcutils_hash_map_t` and must free it and its
+ *   elements, but NOT finalize its values.
+ * - The output `rcutils_hash_map_t` has values that borrows the `referenced_types` arg's
+ *   `IndividualTypeDescription` elements. It is not authorized to delete its values and it cannot
+ *   outlive the `referenced_types` it borrows from.
+ *   - Finalizing the output `rcutils_hash_map_t` should not result in its values getting finalized.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] referenced_types the referenced individual type descriptions to get the referenced
+ *                             types from
+ * \param[in] allocator the allocator to use through out the lifetime of the hash_map
+ * \param[out] hash_map `rcutils_hash_map_t` to be initialized, containing
+ *                      `IndividualTypeDescription` objects keyed by their type names. Must point to
+ *                      `NULL`, outputs pointing to `NULL` if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_get_referenced_type_description_map(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** hash_map);
+
+
+// =================================================================================================
+// DESCRIPTION VALIDITY
+// =================================================================================================
+
+/// Return a map of only the referenced type descriptions that are recursively necessary.
+/**
+ * NOTE: The `seen_map` output arg must be passed in pointing to `NULL`. It's a parameter so it can
+ *       be passed into subsequent recursive calls to traverse nested types.
+ *
+ * A referenced type description is recursively necessary if it is either:
+ *   - Needed by a field of the main IndividualTypeDescription
+ *   - Needed by a field of any prior necessary referenced type descriptions (hence recursive)
+ *
+ * For more clarity, an unnecessary referenced type description will not be
+ * referenced when parsing a TypeDescription, and hence can be excluded.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `rcutils_hash_map_t` and must free it and its
+ *   elements, but NOT finalize its values.
+ * - The output `rcutils_hash_map_t` has values that borrows the `referenced_types_map` arg's
+ *   `IndividualTypeDescription` values. It is not authorized to delete its values and it cannot
+ *   outlive owner it borrows from.
+ *   - Finalizing the output `rcutils_hash_map_t` should not result in its values getting finalized.
+ *
+ * Procedure:
+ *   1. Create seen map
+ *   2. [Iterate through fields]:
+ *     3. If field is not nested type or field's nested type is seen in the seen map:
+ *       - Continue
+ *     4. If nested type is missing in referenced types or nested type name is empty:
+ *       - Throw error
+ *     5. Else:
+ *       - Add to seen map
+ *       - Recurse on referenced type
+ *   6. Output seen map
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] main_type_description the main individual type description to check the fields of
+ * \param[in] referenced_types_map a map of referenced `IndividualTypeDescription` objects from the
+ *                                 main individual type description's parent `TypeDescription`
+ *                                 object, keyed by their type names
+ * \param[in] allocator the allocator to use through out the lifetime of the hash_map
+ * \param[in,out] seen_map `rcutils_hash_map_t` of seen necessary `IndividualTypeDescription`
+ *                         objects keyed by their type names. Used in recursive calls. Must point to
+ *                         `NULL` for user's top level call, outputs pointing to `NULL` if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_NOT_FOUND if passed referenced types are missing necessary types, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+  const type_description_interfaces__msg__IndividualTypeDescription * main_type_description,
+  const rcutils_hash_map_t * referenced_types_map,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** seen_map);
+
+/// Deep copy a map of individual type descriptions into a new IndividualTypeDescription__Sequence.
+/**
+ * NOTE: The `sequence` output arg must be passed in pointing to `NULL`.
+ *
+ * This method also validates that each IndividualTypeDescription in the map has a type name that
+ * matches the key it was indexed by.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `IndividualTypeDescription__Sequence` and must free
+ *   it.
+ * - The output `IndividualTypeDescription__Sequence` deep copies the values from the `hash_map` arg
+ *   and so has a separate lifetime from the `hash_map`.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] hash_map the referenced type descriptions map to convert (via deep copy) to a sequence
+ * \param[out] sequence the `IndividualTypeDescription__Sequence` containing copies of the
+ *                      `IndividualTypeDescription` objects stored in the values of the input
+ *                      `hash_map` arg. Must point to `NULL`, outputs pointing to `NULL` if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_copy_init_sequence_from_referenced_type_descriptions_map(
+  const rcutils_hash_map_t * hash_map,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence ** sequence);
+
+/// Comparison for type_description_interfaces_utils_sort_referenced_type_descriptions_in_place
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+int
+type_description_interfaces_utils_referenced_type_description_sequence_sort_compare(
+  const void * lhs, const void * rhs);
+
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * sequence);
+
+/// Remove unnecessary referenced type descriptions from a sequence of referenced types.
+/// IndividualTypeDescription elements are moved around in-place.
+/// DOES NOT SORT AFTER PRUNING!!
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_prune_referenced_type_descriptions_in_place(
+  const type_description_interfaces__msg__IndividualTypeDescription * main_type_description,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types);
+
+/// Check if field is valid
+/**
+ * A field is valid if:
+ *   - Its name is not empty
+ *     - Note this does not check for valid chars/double underscores
+ *   - Its field type:
+ *     - Is set
+ *     - Has a non-empty nested type name if nested
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+bool
+type_description_interfaces_utils_field_is_valid(type_description_interfaces__msg__Field * field);
+
+/// Check if individual type description is valid
+/**
+ * An individual type description is valid if:
+ *   - Its type name is not empty
+ *     - Note this does not check for valid chars etc.
+ *   - All of its fields are valid
+ *   - It does not have duplicate fields
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+bool
+type_description_interfaces_utils_individual_type_description_is_valid(
+  type_description_interfaces__msg__IndividualTypeDescription * description);
+
+/// Check if type description is valid
+/**
+ * An type description is valid if:
+ *   - Its main individual type description is valid
+ *   - Its referenced type descriptions are:
+ *     - Not duplicated
+ *     - Not missing necessary type descriptions
+ *     - Have no unnecessary type descriptions
+ *     - Individually valid
+ *     - Sorted
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+bool
+type_description_interfaces_utils_type_description_is_valid(
+  type_description_interfaces__msg__TypeDescription * description);
+
+/// This is on a best effort basis, it won't work if the fields of the main or necessary referenced
+/// types are invalid
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_coerce_to_valid_type_description_in_place(
+  type_description_interfaces__msg__TypeDescription * type_description);
+
+
+// =================================================================================================
+// DESCRIPTION CONSTRUCTION
+// =================================================================================================
+
+/// Construct a new populated `Field` object.
+/**
+ * NOTE: The `field` output arg must be passed in pointing to `NULL`.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `Field` and must free it and its members.
+ * - The char * members are copied.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] name the name of the field
+ * \param[in] name_length the string length of `name` (not counting the null terminator)
+ * \param[in] type_id the type id of the field (follows the type_description_interfaces definition)
+ * \param[in] capacity capacity of the field (if it is an array or sequence)
+ * \param[in] string_capacity capacity of string elements (if the field is an array or sequence of
+ *                            strings)
+ * \param[in] nested_type_name the nested type name of the field (if it is a nested type)
+ * \param[in] nested_type_name_length the string length of `nested_type_name` (not counting the null
+ *                                    terminator)
+ * \param[in] default_value literal default value of the field as a string, as it appeared in the
+ *                          original message definition
+ * \param[in] default_value_length the string length of `default_value` (not counting the null
+ *                                    terminator)
+ * \param[out] field `Field` to be initialized. Must point to `NULL`, outputs pointing to `NULL` if
+ *                   error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_create_field(
+  const char * name, size_t name_length,
+  uint8_t type_id, uint64_t capacity, uint64_t string_capacity,
+  const char * nested_type_name, size_t nested_type_name_length,
+  const char * default_value, size_t default_value_length,
+  type_description_interfaces__msg__Field ** field);
+
+/// Construct a new populated `IndividualTypeDescription` object, with fields sequence of size 0.
+/**
+ * NOTE: The `individual_description` output arg must be passed in pointing to `NULL`.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `IndividualTypeDescription` and must free it and its
+ *   members.
+ * - The char * members are copied.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] type_name the name of the individual type description
+ * \param[in] type_name_length the string length of `type_name` (not counting the null terminator)
+ * \param[out] individual_description `IndividualTypeDescription` to be initialized. Must point to
+ *                                    `NULL`, outputs pointing to `NULL` if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_create_individual_type_description(
+  const char * type_name, size_t type_name_length,
+  type_description_interfaces__msg__IndividualTypeDescription ** individual_description);
+
+/// Construct a new populated `TypeDescription` object, with fields and referenced types sequences
+/// of size 0.
+/**
+ * NOTE: The `description` output arg must be passed in pointing to `NULL`.
+ *
+ * Ownership:
+ * - The caller assumes ownership of the output `TypeDescription` and must free it and its
+ *   members.
+ * - The char * members are copied.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] type_name the name of the type description's main individual type
+ * \param[in] type_name_length the string length of `type_name` (not counting the null terminator)
+ * \param[out] type_description `TypeDescription` to be initialized. Must point to `NULL`,
+ *                                    outputs pointing to `NULL` if error.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_create_type_description(
+  const char * type_name, size_t type_name_length,
+  type_description_interfaces__msg__TypeDescription ** type_description);
+
+/// Append a `Field` to an `IndividualTypeDescription`, extending the sequence.
+/**
+ *
+ * Ownership:
+ * - A deep-copy of the `field` is appended to `individual_type_description` on success, the
+ *   `individual_type_description` is then responsible for freeing the copied `field`.
+ * - The ownership of the input `field` is not transferred, it must still be freed.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in,out] individual_type_description the individual type description to append to, noop on
+ *                                            failure
+ * \param[in,out] field the field to append
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_append_field(
+  type_description_interfaces__msg__IndividualTypeDescription * individual_type_description,
+  type_description_interfaces__msg__Field * field);
+
+/// Append a referenced `IndividualTypeDescription` to a `TypeDescription`, extending it.
+/**
+ *
+ * Ownership:
+ * - A deep-copy of the `referenced_type_description` is appended to `type_description` on success,
+ *   the `type_description` is then responsible for freeing the copied
+ *   `referenced_type_description`.
+ * - The ownership of the input `referenced_type_description` is not transferred, it must still be
+ *   freed.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in,out] type_description the type description to append to, noop on failure
+ * \param[in,out] individual_type_description the individual type description to append
+ * \param[in] sort sorts the referenced type descriptions if true, best effort
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_append_referenced_individual_type_description(
+  type_description_interfaces__msg__TypeDescription * type_description,
+  type_description_interfaces__msg__IndividualTypeDescription * referenced_type_description,
+  bool sort);
+
+/// Append a referenced `TypeDescription` to a `TypeDescription`, extending it with recursive types.
+/**
+ *
+ * Ownership:
+ * - A deep-copy of the `type_description_to_append` object's main individual type description is
+ *   appended to `type_description` on success, the `type_description` is then responsible for
+ *   freeing the copied individual type descriptions.
+ * - Deep-copies of the `type_description_to_append` object's referenced individual type
+ *   descriptions are appended to `type_description` on success, the `type_description` is then
+ *   responsible for freeing the copied individual type descriptions (or the remaining ones if
+ *   they are pruned).
+ * - The ownership of the input `type_description` is not transferred, it must still be
+ *   freed.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in,out] type_description the type description to append to, noop on failure
+ * \param[in,out] type_description the type description to append
+ * \param[in] coerce_to_valid coerces input type_description to valid before output if true
+ *                            (pruning and sorting), best effort
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
+ */
+// This adds the type description's main description as a referenced type, and all necessary
+// referenced types. Then it prunes and sorts the resulting referenced types sequence.
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_append_referenced_type_description(
+  type_description_interfaces__msg__TypeDescription * type_description,
+  type_description_interfaces__msg__TypeDescription * type_description_to_append,
+  bool coerce_to_valid);
+
+// Copy main type description, then validate
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+rcutils_ret_t
+type_description_interfaces_utils_get_referenced_type_description_as_type_description(
+  type_description_interfaces__msg__TypeDescription * parent_description,
+  type_description_interfaces__msg__IndividualTypeDescription * referenced_description,
+  type_description_interfaces__msg__TypeDescription ** output_description);
+
+
+// =================================================================================================
+// DESCRIPTION PRINTING
+// =================================================================================================
+
+/// Print type_description_interfaces__msg__FieldType
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void
+type_description_interfaces_utils_print_field_type(
+  const type_description_interfaces__msg__FieldType * field_type);
+
+/// Print type_description_interfaces__msg__Field
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void
+type_description_interfaces_utils_print_field(
+  const type_description_interfaces__msg__Field * field);
+
+/// Print type_description_interfaces__msg__IndividualTypeDescription
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void
+type_description_interfaces_utils_print_individual_type_description(
+  const type_description_interfaces__msg__IndividualTypeDescription * individual_type_description);
+
+/// Print type_description_interfaces__msg__TypeDescription
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void type_description_interfaces_utils_print_type_description(
+  const type_description_interfaces__msg__TypeDescription * type_description);
+
+/// Print hashmap of type_description_interfaces__msg__Field, keyed by name
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void
+type_description_interfaces_utils_print_field_map(const rcutils_hash_map_t * hash_map);
+
+/// Print hashmap of type_description_interfaces__msg__IndividualTypeDescription, keyed by name
+TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+void
+type_description_interfaces_utils_print_referenced_type_description_map(
+  const rcutils_hash_map_t * hash_map);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES_UTILS__UTILS_H_

--- a/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
+++ b/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
@@ -596,7 +596,7 @@ type_description_interfaces_utils_append_referenced_type_description(
 TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
 rcutils_ret_t
 type_description_interfaces_utils_get_referenced_type_description_as_type_description(
-  type_description_interfaces__msg__TypeDescription * parent_description,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_descriptions,
   type_description_interfaces__msg__IndividualTypeDescription * referenced_description,
   type_description_interfaces__msg__TypeDescription ** output_description,
   bool coerce_to_valid);

--- a/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
+++ b/type_description_interfaces_utils/include/type_description_interfaces_utils/utils.h
@@ -162,6 +162,8 @@ type_description_interfaces_utils_get_field_map(
 /// objects, keyed by type name.
 /**
  * NOTE: The `hash_map` output arg must be passed in pointing to `NULL`.
+ *       Furthermore, if the input `referenced_types` sequence has types with identical names but
+ *       differing structures, this function will return `RCUTILS_RET_INVALID_ARGUMENT` and fail.
  *
  * Ownership:
  * - The caller assumes ownership of the output `rcutils_hash_map_t` and must free it and its
@@ -289,6 +291,7 @@ type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map
  * \param[out] sequence the `IndividualTypeDescription__Sequence` containing copies of the
  *                      `IndividualTypeDescription` objects stored in the values of the input
  *                      `hash_map` arg. Must point to `NULL`, outputs pointing to `NULL` if error.
+ * \param[in] sort sorts the referenced type descriptions if true, best effort
  * \return #RCUTILS_RET_OK if successful, or
  * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
  * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
@@ -298,7 +301,8 @@ TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
 rcutils_ret_t
 type_description_interfaces_utils_copy_init_sequence_from_referenced_type_descriptions_map(
   const rcutils_hash_map_t * hash_map,
-  type_description_interfaces__msg__IndividualTypeDescription__Sequence ** sequence);
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence ** sequence,
+  bool sort);
 
 /// Comparison for type_description_interfaces_utils_sort_referenced_type_descriptions_in_place
 TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
@@ -312,8 +316,9 @@ type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
   type_description_interfaces__msg__IndividualTypeDescription__Sequence * sequence);
 
 /// Remove unnecessary referenced type descriptions from a sequence of referenced types.
-/// IndividualTypeDescription elements are moved around in-place.
-/// DOES NOT SORT AFTER PRUNING!!
+/// IndividualTypeDescription elements are COPY ASSIGNED in-place, and the original sequence is
+/// shrunken afterwards.
+/// NOTE: DOES NOT SORT AFTER PRUNING! Call sort separately.
 TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
 rcutils_ret_t
 type_description_interfaces_utils_prune_referenced_type_descriptions_in_place(
@@ -363,7 +368,7 @@ type_description_interfaces_utils_type_description_is_valid(
   type_description_interfaces__msg__TypeDescription * description);
 
 /// This is on a best effort basis, it won't work if the fields of the main or necessary referenced
-/// types are invalid
+/// types are invalid. It prunes then sorts.
 TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
 rcutils_ret_t
 type_description_interfaces_utils_coerce_to_valid_type_description_in_place(
@@ -587,13 +592,14 @@ type_description_interfaces_utils_append_referenced_type_description(
   type_description_interfaces__msg__TypeDescription * type_description_to_append,
   bool coerce_to_valid);
 
-// Copy main type description, then validate
+// Copy main type description, then validate if coerce_to_valid is true
 TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
 rcutils_ret_t
 type_description_interfaces_utils_get_referenced_type_description_as_type_description(
   type_description_interfaces__msg__TypeDescription * parent_description,
   type_description_interfaces__msg__IndividualTypeDescription * referenced_description,
-  type_description_interfaces__msg__TypeDescription ** output_description);
+  type_description_interfaces__msg__TypeDescription ** output_description,
+  bool coerce_to_valid);
 
 
 // =================================================================================================

--- a/type_description_interfaces_utils/include/type_description_interfaces_utils/visibility_control.h
+++ b/type_description_interfaces_utils/include/type_description_interfaces_utils/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPE_DESCRIPTION_INTERFACES_UTILS__VISIBILITY_CONTROL_H_
+#define TYPE_DESCRIPTION_INTERFACES_UTILS__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_EXPORT __attribute__ ((dllexport))
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_IMPORT __attribute__ ((dllimport))
+  #else
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_EXPORT __declspec(dllexport)
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef TYPE_DESCRIPTION_INTERFACES_UTILS_BUILDING_DLL
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC TYPE_DESCRIPTION_INTERFACES_UTILS_EXPORT
+  #else
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC TYPE_DESCRIPTION_INTERFACES_UTILS_IMPORT
+  #endif
+  #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC_TYPE TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+  #define TYPE_DESCRIPTION_INTERFACES_UTILS_LOCAL
+#else
+  #define TYPE_DESCRIPTION_INTERFACES_UTILS_EXPORT __attribute__ ((visibility("default")))
+  #define TYPE_DESCRIPTION_INTERFACES_UTILS_IMPORT
+  #if __GNUC__ >= 4
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC __attribute__ ((visibility("default")))
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC
+    #define TYPE_DESCRIPTION_INTERFACES_UTILS_LOCAL
+  #endif
+  #define TYPE_DESCRIPTION_INTERFACES_UTILS_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPE_DESCRIPTION_INTERFACES_UTILS__VISIBILITY_CONTROL_H_

--- a/type_description_interfaces_utils/package.xml
+++ b/type_description_interfaces_utils/package.xml
@@ -13,11 +13,10 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_depend>rcutils</build_depend>
-  <build_depend>type_description_interfaces</build_depend>
+  <depend>rcutils</depend>
+  <depend>type_description_interfaces_static</depend>
 
-  <test_depend>rcutils</test_depend>
-  <test_depend>type_description_interfaces</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/type_description_interfaces_utils/package.xml
+++ b/type_description_interfaces_utils/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>type_description_interfaces_utils</name>
+  <version>0.0.1</version>
+  <description>Utilities for manipulating type_description_interfaces C message structs.</description>
+  <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
+
+  <license>Apache License 2.0</license>
+  <author email="brandon@openrobotics.org">Brandon Ong</author>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <build_depend>rcutils</build_depend>
+  <build_depend>type_description_interfaces</build_depend>
+
+  <test_depend>rcutils</test_depend>
+  <test_depend>type_description_interfaces</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/type_description_interfaces_utils/src/utils.c
+++ b/type_description_interfaces_utils/src/utils.c
@@ -1,0 +1,1308 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE(methylDragon): Maybe this belongs inside the type_description_interfaces
+//                     package instead?
+//                     But as a C header (.h)???
+
+// NOTE(methylDragon): I made it so that every instance of a non-message struct (e.g. hash map)
+//                     borrows, whereas the message structs copy.
+//                     So lifetime should be managed by the message structs.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <type_description_interfaces_utils/utils.h>
+
+#include <rcutils/logging_macros.h>
+#include <rcutils/qsort.h>
+#include <rcutils/types/rcutils_ret.h>
+#include <rcutils/types/hash_map.h>
+#include <rosidl_runtime_c/string_functions.h>
+
+#include <type_description_interfaces/msg/field.h>
+#include <type_description_interfaces/msg/individual_type_description.h>
+#include <type_description_interfaces/msg/type_description.h>
+
+
+// =================================================================================================
+// GET BY NAME
+// =================================================================================================
+
+rcutils_ret_t
+type_description_interfaces_utils_find_field(
+  const type_description_interfaces__msg__Field__Sequence * fields,
+  const char * name,
+  type_description_interfaces__msg__Field ** field)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(fields, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(name, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(field, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*field != NULL) {
+    RCUTILS_LOG_ERROR("`field` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  for (size_t i = 0; i < fields->size; i++) {
+    if (strcmp(fields->data[i].name.data, name) == 0) {
+      *field = &fields->data[i];
+      return RCUTILS_RET_OK;
+    }
+  }
+
+  RCUTILS_LOG_WARN("Could not find field: %s", name);
+  return RCUTILS_RET_NOT_FOUND;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_find_referenced_type_description(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types,
+  const char * type_name,
+  type_description_interfaces__msg__IndividualTypeDescription ** referenced_type)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_types, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_name, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_type, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*referenced_type != NULL) {
+    RCUTILS_LOG_ERROR("`referenced_type` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  for (size_t i = 0; i < referenced_types->size; i++) {
+    if (strcmp(referenced_types->data[i].type_name.data, type_name) == 0) {
+      *referenced_type = &referenced_types->data[i];
+      return RCUTILS_RET_OK;
+    }
+  }
+
+  RCUTILS_LOG_WARN("Could not find referenced type description: %s", type_name);
+  return RCUTILS_RET_NOT_FOUND;
+}
+
+
+// =================================================================================================
+// HASH MAPS
+// =================================================================================================
+
+rcutils_ret_t
+type_description_interfaces_utils_get_field_map(
+  const type_description_interfaces__msg__IndividualTypeDescription * individual_description,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** hash_map)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(individual_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(hash_map, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*hash_map != NULL) {
+    RCUTILS_LOG_ERROR("`hash_map` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  rcutils_hash_map_t * out = allocator->allocate(sizeof(rcutils_hash_map_t), allocator->state);
+  if (out == NULL) {
+    RCUTILS_LOG_ERROR("Could not allocate output hash map");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  *out = rcutils_get_zero_initialized_hash_map();
+
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+  rcutils_ret_t fail_ret = RCUTILS_RET_ERROR;
+
+  ret = rcutils_hash_map_init(
+    out, individual_description->fields.size,
+    sizeof(char *), sizeof(type_description_interfaces__msg__Field *),
+    rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func,
+    allocator);
+  if (ret != RCUTILS_RET_OK) {
+    allocator->deallocate(out, allocator->state);
+    RCUTILS_LOG_ERROR("Could not init hash map");
+    return ret;
+  }
+
+  for (size_t i = 0; i < individual_description->fields.size; i++) {
+    type_description_interfaces__msg__Field * tmp = &individual_description->fields.data[i];
+    // Passing tmp is fine even if tmp goes out of scope later since it copies in the set method...
+    ret = rcutils_hash_map_set(out, &individual_description->fields.data[i].name.data, &tmp);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR(
+        "Could not set hash map entry for field: %s",
+        individual_description->fields.data[i].name.data);
+      fail_ret = ret;
+      goto fail;
+    }
+  }
+
+  *hash_map = out;
+  return RCUTILS_RET_OK;
+
+fail:
+  {
+    rcutils_ret_t fini_ret = rcutils_hash_map_fini(out);
+    if (fini_ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to finalize hash map");
+    }
+    allocator->deallocate(out, allocator->state);
+  }
+  return fail_ret;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_get_referenced_type_description_map(
+  const type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** hash_map)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_types, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(hash_map, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*hash_map != NULL) {
+    RCUTILS_LOG_ERROR("`hash_map` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  rcutils_hash_map_t * out = allocator->allocate(sizeof(rcutils_hash_map_t), allocator->state);
+  if (out == NULL) {
+    RCUTILS_LOG_ERROR("Could not allocate output hash map");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  *out = rcutils_get_zero_initialized_hash_map();
+
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+  rcutils_ret_t fail_ret = RCUTILS_RET_ERROR;
+
+  ret = rcutils_hash_map_init(
+    out, referenced_types->size,
+    sizeof(char *), sizeof(type_description_interfaces__msg__IndividualTypeDescription *),
+    rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func,
+    allocator);
+  if (ret != RCUTILS_RET_OK) {
+    allocator->deallocate(out, allocator->state);
+    RCUTILS_LOG_ERROR("Could not init hash map");
+    return ret;
+  }
+
+  for (size_t i = 0; i < referenced_types->size; i++) {
+    type_description_interfaces__msg__IndividualTypeDescription * tmp = &referenced_types->data[i];
+    // Passing tmp is fine even if tmp goes out of scope later since it copies in the set method...
+    ret = rcutils_hash_map_set(out, &referenced_types->data[i].type_name.data, &tmp);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR(
+        "Could not set hash map entry for referenced type: %s",
+        referenced_types->data[i].type_name.data);
+      fail_ret = ret;
+      goto fail;
+    }
+  }
+
+  size_t map_length;
+  ret = rcutils_hash_map_get_size(out, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not get size of hash map for validation");
+    fail_ret = RCUTILS_RET_ERROR;
+    goto fail;
+  }
+
+  if (referenced_types->size != map_length) {  // Duplicate referenced types is invalid
+    RCUTILS_LOG_ERROR("Passed referenced IndividualTypeDescriptions has duplicate types");
+    fail_ret = RCUTILS_RET_INVALID_ARGUMENT;
+    goto fail;
+  }
+
+  *hash_map = out;
+  return RCUTILS_RET_OK;
+
+fail:
+  {
+    rcutils_ret_t fini_ret = rcutils_hash_map_fini(out);
+    if (fini_ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to finalize hash map");
+    }
+    allocator->deallocate(out, allocator->state);
+  }
+  return fail_ret;
+}
+
+
+// =================================================================================================
+// DESCRIPTION VALIDITY
+// =================================================================================================
+
+rcutils_ret_t
+type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+  const type_description_interfaces__msg__IndividualTypeDescription * main_type_description,
+  const rcutils_hash_map_t * referenced_types_map,
+  const rcutils_allocator_t * allocator,
+  rcutils_hash_map_t ** seen_map)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(main_type_description, RCUTILS_RET_INVALID_ARGUMENT);
+  HASH_MAP_VALIDATE_HASH_MAP(referenced_types_map);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(seen_map, RCUTILS_RET_INVALID_ARGUMENT);
+
+  // Only true for the top level call, so we can determine when to finalize the map
+  bool top_level_call = false;
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+  rcutils_ret_t fail_ret = RCUTILS_RET_ERROR;
+
+  // 1. Init new hash map only on the top level call
+  if (!*seen_map) {
+    top_level_call = true;
+
+    *seen_map = allocator->allocate(sizeof(rcutils_hash_map_t), allocator->state);
+    if (*seen_map == NULL) {
+      RCUTILS_LOG_ERROR("Could not allocate hash map");
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+    **seen_map = rcutils_get_zero_initialized_hash_map();
+
+    size_t referenced_types_map_size;
+    ret = rcutils_hash_map_get_size(referenced_types_map, &referenced_types_map_size);
+    if (ret != RCUTILS_RET_OK) {
+      allocator->deallocate(*seen_map, allocator->state);
+      RCUTILS_LOG_ERROR("Could not get size of referenced types hash map");
+      *seen_map = NULL;
+      return RCUTILS_RET_ERROR;
+    }
+
+    ret = rcutils_hash_map_init(
+      *seen_map, referenced_types_map_size,
+      sizeof(char *), sizeof(type_description_interfaces__msg__IndividualTypeDescription *),
+      rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func,
+      allocator);
+    if (ret != RCUTILS_RET_OK) {
+      allocator->deallocate(*seen_map, allocator->state);
+      RCUTILS_LOG_ERROR("Could not init hash map");
+      *seen_map = NULL;
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+  }
+
+  // 2. Iterate through fields
+  for (size_t i = 0; i < main_type_description->fields.size; i++) {
+    type_description_interfaces__msg__Field * field = &main_type_description->fields.data[i];
+    // 3. Skip cases
+    // continue if field is not nested type or nested type is in seen map:
+    if ((field->type.type_id % TYPE_DESCRIPTION_INTERFACES_UTILS_SEQUENCE_TYPE_ID_DELIMITER) != 1 ||
+      rcutils_hash_map_key_exists(*seen_map, field->type.nested_type_name.data))
+    {
+      continue;
+    }
+
+    // 4. Error cases
+    // Referenced type does not exist
+    if (!rcutils_hash_map_key_exists(referenced_types_map, field->type.nested_type_name.data)) {
+      RCUTILS_LOG_ERROR("Missing referenced type: %s", field->type.nested_type_name.data);
+      fail_ret = RCUTILS_RET_NOT_FOUND;
+      goto fail;
+    }
+    // Nested name empty
+    if (field->type.nested_type_name.size == 0) {
+      RCUTILS_LOG_ERROR("Missing referenced type name");
+      fail_ret = RCUTILS_RET_INVALID_ARGUMENT;
+      goto fail;
+    }
+
+    // 5. Add to seen map (we didn't skip and didn't error out)
+    type_description_interfaces__msg__IndividualTypeDescription * necessary_description;
+    ret = rcutils_hash_map_get(
+      *seen_map, field->type.nested_type_name.data, &necessary_description);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR(
+        "Couldn't get necessary referenced type: %s", field->type.nested_type_name.data);
+      fail_ret = ret;  // Most likely a RCUTILS_RET_NOT_FOUND
+      goto fail;
+    }
+
+    // Check for mismatched name
+    if (strcmp(field->type.nested_type_name.data, necessary_description->type_name.data) != 0) {
+      RCUTILS_LOG_ERROR(
+        "Necessary referenced type name (%s) did not match field's nested type name (%s)",
+        necessary_description->type_name.data,
+        field->type.nested_type_name.data);
+      fail_ret = RCUTILS_RET_INVALID_ARGUMENT;
+      goto fail;
+    }
+
+    // Add to map (finally!!)
+    ret = rcutils_hash_map_set(
+      *seen_map, &field->type.nested_type_name.data, necessary_description);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to set hash map for key: %s", field->type.nested_type_name.data);
+      fail_ret = ret;
+      goto fail;
+    }
+
+    // Recurse on fields on necessary_description
+    ret = type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+      necessary_description, referenced_types_map, allocator, seen_map);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Recursion failed on: %s", necessary_description->type_name.data);
+      fail_ret = ret;
+      goto fail;
+    }
+  }  // End field iteration
+
+  return RCUTILS_RET_OK;
+
+fail:
+  if (top_level_call) {
+    rcutils_ret_t fini_ret = rcutils_hash_map_fini(*seen_map);
+    if (fini_ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to finalize hash map");
+    }
+    allocator->deallocate(*seen_map, allocator->state);
+    *seen_map = NULL;
+  }
+  return fail_ret;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_copy_init_sequence_from_referenced_type_descriptions_map(
+  const rcutils_hash_map_t * hash_map,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence ** sequence)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(hash_map, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*sequence != NULL) {
+    RCUTILS_LOG_ERROR("`sequence` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  size_t map_length;
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+  ret = rcutils_hash_map_get_size(hash_map, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not get size of hash map");
+    return RCUTILS_RET_ERROR;
+  }
+  *sequence = type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(
+    map_length);
+  if (*sequence == NULL) {
+    RCUTILS_LOG_ERROR("Could allocate sequence");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  size_t i = 0;
+  char * key;
+  type_description_interfaces__msg__IndividualTypeDescription * data;
+  rcutils_ret_t status = rcutils_hash_map_get_next_key_and_data(hash_map, NULL, &key, &data);
+  while (RCUTILS_RET_OK == status) {
+    if (strcmp(key, data->type_name.data) != 0) {
+      RCUTILS_LOG_ERROR(
+        "Necessary referenced type name (%s) did not match key (%s)", data->type_name.data, key);
+      type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(*sequence);
+      return RCUTILS_RET_INVALID_ARGUMENT;
+    }
+
+    // Deep copy
+    if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+        data, &((*sequence)->data[i])))
+    {
+      RCUTILS_LOG_ERROR("Could not copy type %s to sequence", key);
+      type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(*sequence);
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+
+    i += 1;
+    status = rcutils_hash_map_get_next_key_and_data(hash_map, &key, &key, &data);
+  }
+
+  return RCUTILS_RET_OK;
+}
+
+
+int
+type_description_interfaces_utils_referenced_type_description_sequence_sort_compare(
+  const void * lhs, const void * rhs)
+{
+  type_description_interfaces__msg__IndividualTypeDescription * left =
+    *(type_description_interfaces__msg__IndividualTypeDescription **)lhs;
+  type_description_interfaces__msg__IndividualTypeDescription * right =
+    *(type_description_interfaces__msg__IndividualTypeDescription **)rhs;
+  if (left == NULL) {
+    return right == NULL ? 0 : 1;
+  } else if (right == NULL) {
+    return -1;
+  }
+  return strcmp(left->type_name.data, right->type_name.data);
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * sequence)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(sequence, RCUTILS_RET_INVALID_ARGUMENT);
+  return rcutils_qsort(
+    sequence->data,
+    sequence->size,
+    sizeof(sequence->data[0]),
+    type_description_interfaces_utils_referenced_type_description_sequence_sort_compare);
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_prune_referenced_type_descriptions_in_place(
+  const type_description_interfaces__msg__IndividualTypeDescription * main_type_description,
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * referenced_types)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(main_type_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_types, RCUTILS_RET_INVALID_ARGUMENT);
+
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+  rcutils_ret_t end_ret = RCUTILS_RET_ERROR;
+
+  rcutils_hash_map_t * referenced_types_map = NULL;
+  rcutils_hash_map_t * seen_map = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  ret = type_description_interfaces_utils_get_referenced_type_description_map(
+    referenced_types, &allocator, &referenced_types_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not construct referenced type description map");
+    return ret;
+  }
+
+  ret = type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+    main_type_description, referenced_types_map, &allocator, &seen_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not construct necessary referenced type description map");
+    return ret;
+  }
+
+  size_t map_length;
+  ret = rcutils_hash_map_get_size(seen_map, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not get size of hash map for validation");
+    end_ret = RCUTILS_RET_ERROR;
+    goto end;
+  }
+  // End early if pruning was not needed
+  if ((referenced_types)->size == map_length) {
+    end_ret = RCUTILS_RET_OK;
+    goto end;
+  }
+
+  // Otherwise, we need to rearrange and resize the sequence
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * out =
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(map_length);
+
+  // First obtain all necessary types
+  size_t append_count = 0;
+  for (size_t i = 0; i < referenced_types->size; i++) {
+    if (rcutils_hash_map_key_exists(seen_map, referenced_types->data[i].type_name.data)) {
+      // Transfer ownership of necessary referenced types from input sequence to output sequence,
+      // NOTE(methylDragon): We can't just swap the sequence elements with NULL since they're
+      //                     values, not pointers...
+      out->data[append_count++] = referenced_types->data[i];
+    } else {
+      // Deleting unnecessary referenced types otherwise
+      type_description_interfaces__msg__IndividualTypeDescription__destroy(
+        &referenced_types->data[i]);
+    }
+  }
+
+  // Then rearrange the input referenced types sequence
+  for (size_t i = 0; i < append_count; i++) {
+    // This is a deep copy, so we don't need to worry about managing pointers in the rearrange
+    if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+        &out->data[i], &referenced_types->data[i]))
+    {
+      RCUTILS_LOG_ERROR(
+        "Could not copy necessary referenced type description sequence during rearrangement! "
+        "Beware! The referenced type descriptions was likely already partially modified in place!");
+      end_ret = RCUTILS_RET_ERROR;
+      type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(out);
+      goto end;
+    }
+  }
+  // Delete entries after the section of necessary referenced types, and shrink the input sequence
+  for (size_t i = append_count; i < referenced_types->size; i++) {
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(
+      &referenced_types->data[i]);
+  }
+  if (allocator.reallocate(referenced_types->data, append_count, allocator.state) == NULL) {
+    RCUTILS_LOG_ERROR(
+      "Could not shrink the necessary referenced type descriptions sequence during rearrangement! "
+      "Beware! The referenced type descriptions was likely already partially modified in place!");
+    end_ret = RCUTILS_RET_BAD_ALLOC;
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(out);
+    goto end;
+  }
+  referenced_types->size = append_count;
+  referenced_types->capacity = append_count;
+
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(out);
+  end_ret = RCUTILS_RET_OK;
+
+end:
+  {
+    rcutils_ret_t fini_ret = rcutils_hash_map_fini(seen_map);
+    if (fini_ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to finalize hash map");
+    }
+    allocator.deallocate(seen_map, allocator.state);
+  }
+
+  return end_ret;
+}
+
+
+bool
+type_description_interfaces_utils_field_is_valid(type_description_interfaces__msg__Field * field)
+{
+  if (field == NULL) {
+    RCUTILS_LOG_WARN("Field is invalid: Pointer is null");
+    return false;
+  }
+  if (field->name.size == 0) {
+    RCUTILS_LOG_WARN("Field is invalid: Empty name");
+    return false;
+  }
+  if ((field->type.type_id % TYPE_DESCRIPTION_INTERFACES_UTILS_SEQUENCE_TYPE_ID_DELIMITER) != 0) {
+    RCUTILS_LOG_WARN("Field `%s` is invalid: Unset type ID", field->name.data);
+    return false;
+  }
+  if ((field->type.type_id % TYPE_DESCRIPTION_INTERFACES_UTILS_SEQUENCE_TYPE_ID_DELIMITER) == 1 &&
+    field->type.nested_type_name.size == 0)
+  {
+    RCUTILS_LOG_WARN(
+      "Field `%s` is invalid: Field is nested but with empty nested type name", field->name.data);
+    return false;
+  }
+  return true;
+}
+
+
+bool
+type_description_interfaces_utils_individual_type_description_is_valid(
+  type_description_interfaces__msg__IndividualTypeDescription * description)
+{
+  if (description == NULL) {
+    RCUTILS_LOG_WARN("Individual type description is invalid: Pointer is null");
+    return false;
+  }
+  if (description->type_name.size == 0) {
+    RCUTILS_LOG_WARN("Individual type description is invalid: Empty name");
+    return false;
+  }
+
+  for (size_t i = 0; i < description->fields.size; i++) {
+    if (!type_description_interfaces_utils_field_is_valid(&description->fields.data[i])) {
+      RCUTILS_LOG_WARN(
+        "Individual type description `%s` is invalid: Invalid field", description->type_name.data);
+      return false;
+    }
+  }
+
+  bool end_ret = false;
+  rcutils_hash_map_t * hash_map = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  rcutils_ret_t ret = type_description_interfaces_utils_get_field_map(
+    description, &allocator, &hash_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not construct field map for validation");
+    return false;
+  }
+
+  size_t map_length;
+  ret = rcutils_hash_map_get_size(hash_map, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not get size of field map for validation");
+    goto end;
+  }
+
+  if (description->fields.size != map_length) {
+    RCUTILS_LOG_WARN(
+      "Individual type description `%s` is invalid: Duplicate fields", description->type_name.data);
+    goto end;
+  }
+
+  end_ret = true;
+
+end:
+  {
+    rcutils_ret_t fini_ret = rcutils_hash_map_fini(hash_map);
+    if (fini_ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_ERROR("Failed to finalize hash map");
+    }
+    allocator.deallocate(hash_map, allocator.state);
+    return end_ret;
+  }
+}
+
+
+bool
+type_description_interfaces_utils_type_description_is_valid(
+  type_description_interfaces__msg__TypeDescription * description)
+{
+  if (description == NULL) {
+    RCUTILS_LOG_WARN("Type description is invalid: Pointer is null");
+    return false;
+  }
+
+  if (!type_description_interfaces_utils_individual_type_description_is_valid(
+      &description->type_description))
+  {
+    if (description->type_description.type_name.size != 0) {
+      RCUTILS_LOG_WARN(
+        "Type description `%s` is invalid: Main type description is invalid",
+        description->type_description.type_name.data);
+    } else {
+      RCUTILS_LOG_WARN("Type description is invalid: Main type description is invalid");
+    }
+    return false;
+  }
+
+  bool end_ret = false;
+  rcutils_hash_map_t * referenced_types_map = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  rcutils_ret_t ret = type_description_interfaces_utils_get_referenced_type_description_map(
+    &description->referenced_type_descriptions, &allocator, &referenced_types_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not construct referenced type description map");
+    return false;
+  }
+
+  size_t map_length;
+
+  // Check no duplicated ref types
+  ret = rcutils_hash_map_get_size(referenced_types_map, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not get size of referenced type description map for validation");
+    goto end_ref;
+  }
+  if (description->referenced_type_descriptions.size != map_length) {
+    RCUTILS_LOG_WARN(
+      "Type description `%s` is invalid: Duplicate referenced type descriptions",
+      description->type_description.type_name.data);
+    goto end_ref;
+  }
+
+  // Check no missing necessary ref types
+  rcutils_hash_map_t * necessary_types_map = NULL;
+  ret = type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+    &description->type_description, referenced_types_map, &allocator, &necessary_types_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not construct necessary referenced type description map");
+    goto end_ref;
+  }
+
+  // Check no unnecessary ref types
+  ret = rcutils_hash_map_get_size(necessary_types_map, &map_length);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR(
+      "Could not get size of necessary referenced type description map for validation");
+    goto end_necessary;
+  }
+
+  if (description->referenced_type_descriptions.size != map_length) {
+    RCUTILS_LOG_WARN(
+      "Type description `%s` is invalid: Unnecessary referenced type descriptions",
+      description->type_description.type_name.data);
+    goto end_necessary;
+  }
+
+  // Check all referenced types valid (the prior checks ensure all of them are necessary)
+  for (size_t i = 0; i < description->referenced_type_descriptions.size; i++) {
+    if (!type_description_interfaces_utils_individual_type_description_is_valid(
+        &description->referenced_type_descriptions.data[i]))
+    {
+      RCUTILS_LOG_WARN(
+        "Type description `%s` is invalid: Invalid referenced type description",
+        description->type_description.type_name.data);
+      goto end_necessary;
+    }
+  }
+
+  // Check referenced types sorted
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * sorted_sequence =
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__create(map_length);
+  if (sorted_sequence == NULL) {
+    RCUTILS_LOG_ERROR("Could allocate sequence for copy of referenced type descriptions");
+    goto end_necessary;
+  }
+  if (type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+      &description->referenced_type_descriptions, sorted_sequence))
+  {
+    RCUTILS_LOG_ERROR("Could not copy referenced type descriptions for validation");
+    goto end_sequence;
+  }
+  ret = type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
+    sorted_sequence);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not sort copy of referenced type descriptions for validation");
+    goto end_sequence;
+  }
+
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(
+      &description->referenced_type_descriptions, sorted_sequence))
+  {
+    RCUTILS_LOG_WARN(
+      "Type description `%s` is invalid: Referenced type descriptions not sorted",
+      description->type_description.type_name.data);
+    goto end_sequence;
+  }
+
+  end_ret = true;
+
+end_sequence:
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(sorted_sequence);
+
+end_necessary:
+  ret = rcutils_hash_map_fini(necessary_types_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to finalize referenced types map");
+  }
+  allocator.deallocate(necessary_types_map, allocator.state);
+
+end_ref:
+  ret = rcutils_hash_map_fini(referenced_types_map);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Failed to finalize referenced types map");
+  }
+  allocator.deallocate(referenced_types_map, allocator.state);
+
+  return end_ret;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_coerce_to_valid_type_description_in_place(
+  type_description_interfaces__msg__TypeDescription * type_description)
+{
+  if (!type_description_interfaces_utils_individual_type_description_is_valid(
+      &type_description->type_description))
+  {
+    RCUTILS_LOG_ERROR("Could not make type description valid: Invalid main type description");
+    return RCUTILS_RET_ERROR;
+  }
+
+  rcutils_ret_t ret;
+  ret = type_description_interfaces_utils_prune_referenced_type_descriptions_in_place(
+    &type_description->type_description, &type_description->referenced_type_descriptions);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_WARN(
+      "Could not make type description valid: Could not prune referenced_type_descriptions");
+    return ret;
+  }
+
+  ret = type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
+    &type_description->referenced_type_descriptions);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_WARN(
+      "Could not make type description valid: Could not sort referenced_type_descriptions");
+    return ret;
+  }
+
+  return RCUTILS_RET_OK;
+}
+
+
+// =================================================================================================
+// DESCRIPTION CONSTRUCTION
+// =================================================================================================
+
+rcutils_ret_t
+type_description_interfaces_utils_create_field(
+  const char * name, size_t name_length,
+  uint8_t type_id, uint64_t capacity, uint64_t string_capacity,
+  const char * nested_type_name, size_t nested_type_name_length,
+  const char * default_value, size_t default_value_length,
+  type_description_interfaces__msg__Field ** field)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(name, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(nested_type_name, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(default_value, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*field != NULL) {
+    RCUTILS_LOG_ERROR("`field` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  *field = type_description_interfaces__msg__Field__create();
+
+  // Field
+  if (!rosidl_runtime_c__String__assignn(&(*field)->name, name, name_length)) {
+    RCUTILS_LOG_ERROR("Could not assign field name");
+    type_description_interfaces__msg__Field__destroy(*field);
+    *field = NULL;
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  if (!rosidl_runtime_c__String__assignn(
+      &(*field)->default_value, default_value, default_value_length))
+  {
+    RCUTILS_LOG_ERROR("Could not assign field default value");
+    type_description_interfaces__msg__Field__destroy(*field);
+    *field = NULL;
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  // FieldType
+  (*field)->type.type_id = type_id;
+  (*field)->type.capacity = capacity;
+  (*field)->type.string_capacity = string_capacity;
+
+  if (!rosidl_runtime_c__String__assignn(
+      &(*field)->type.nested_type_name, nested_type_name, nested_type_name_length))
+  {
+    RCUTILS_LOG_ERROR("Could not assign field nested type name");
+    type_description_interfaces__msg__Field__destroy(*field);
+    *field = NULL;
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  return RCUTILS_RET_OK;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_create_individual_type_description(
+  const char * type_name, size_t type_name_length,
+  type_description_interfaces__msg__IndividualTypeDescription ** individual_description)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_name, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*individual_description != NULL) {
+    RCUTILS_LOG_ERROR("`individual_description` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  *individual_description = type_description_interfaces__msg__IndividualTypeDescription__create();
+
+  if (!rosidl_runtime_c__String__assignn(
+      &(*individual_description)->type_name, type_name, type_name_length))
+  {
+    RCUTILS_LOG_ERROR("Could not assign individual description type name");
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(*individual_description);
+    *individual_description = NULL;
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  return RCUTILS_RET_OK;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_create_type_description(
+  const char * type_name, size_t type_name_length,
+  type_description_interfaces__msg__TypeDescription ** type_description)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_name, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*type_description != NULL) {
+    RCUTILS_LOG_ERROR("`type_description` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  *type_description = type_description_interfaces__msg__TypeDescription__create();
+
+  if (!rosidl_runtime_c__String__assignn(
+      &(*type_description)->type_description.type_name, type_name, type_name_length))
+  {
+    RCUTILS_LOG_ERROR("Could not assign main individual description type name");
+    type_description_interfaces__msg__TypeDescription__destroy(*type_description);
+    *type_description = NULL;
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  return RCUTILS_RET_OK;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_append_field(
+  type_description_interfaces__msg__IndividualTypeDescription * individual_type_description,
+  type_description_interfaces__msg__Field * field)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(individual_type_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(field, RCUTILS_RET_INVALID_ARGUMENT);
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t fini_ret = RCUTILS_RET_ERROR;
+
+  size_t allocation_size = (
+    (individual_type_description->fields.size + 1) *
+    sizeof(type_description_interfaces__msg__Field)
+  );
+  type_description_interfaces__msg__Field * next_ptr = allocator.reallocate(
+    individual_type_description->fields.data, allocation_size, allocator.state);
+  if (next_ptr == NULL) {
+    RCUTILS_LOG_ERROR("Could not realloc individual type description fields sequence");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  if (!type_description_interfaces__msg__Field__init(next_ptr)) {
+    RCUTILS_LOG_ERROR("Could not init new individual type description field element");
+    fini_ret = RCUTILS_RET_BAD_ALLOC;
+    goto fail;
+  }
+
+  if (!type_description_interfaces__msg__Field__copy(field, next_ptr)) {
+    RCUTILS_LOG_ERROR("Could not copy into new individual type description field element");
+    type_description_interfaces__msg__Field__fini(next_ptr);
+    fini_ret = RCUTILS_RET_ERROR;
+    goto fail;
+  }
+
+  individual_type_description->fields.data = next_ptr;
+  individual_type_description->fields.size += 1;
+  individual_type_description->fields.capacity += 1;
+  return RCUTILS_RET_OK;
+
+fail:
+  next_ptr = allocator.reallocate(
+    individual_type_description->fields.data,
+    individual_type_description->fields.size,
+    allocator.state);
+  if (next_ptr == NULL) {
+    RCUTILS_LOG_ERROR(
+      "Could not shorten individual type description fields sequence. "
+      "Excess memory will be UNINITIALIZED!");
+    individual_type_description->fields.size += 1;
+    individual_type_description->fields.capacity += 1;
+  }
+  return fini_ret;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_append_referenced_individual_type_description(
+  type_description_interfaces__msg__TypeDescription * type_description,
+  type_description_interfaces__msg__IndividualTypeDescription * referenced_type_description,
+  bool sort)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_type_description, RCUTILS_RET_INVALID_ARGUMENT);
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  type_description_interfaces__msg__IndividualTypeDescription * next_ptr = allocator.reallocate(
+    type_description->referenced_type_descriptions.data,
+    type_description->referenced_type_descriptions.size + 1,
+    allocator.state);
+  if (next_ptr == NULL) {
+    RCUTILS_LOG_ERROR("Could not realloc type description referenced type descriptions sequence");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  if (!type_description_interfaces__msg__IndividualTypeDescription__init(next_ptr)) {
+    RCUTILS_LOG_ERROR("Could not init new type description referenced type descriptions element");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+      referenced_type_description, next_ptr))
+  {
+    // Attempt to undo changes on failure
+    RCUTILS_LOG_ERROR(
+      "Could not copy into new type description referenced type descriptions element");
+    type_description_interfaces__msg__IndividualTypeDescription__fini(next_ptr);
+    next_ptr = allocator.reallocate(
+      type_description->referenced_type_descriptions.data,
+      type_description->referenced_type_descriptions.size,
+      allocator.state);
+    if (next_ptr == NULL) {
+      RCUTILS_LOG_ERROR(
+        "Could not shorten type description referenced type descriptions sequence. "
+        "Excess memory will be UNINITIALIZED!");
+      type_description->referenced_type_descriptions.size += 1;
+      type_description->referenced_type_descriptions.capacity += 1;
+    }
+    return RCUTILS_RET_ERROR;
+  }
+
+  if (sort) {
+    rcutils_ret_t ret =
+      type_description_interfaces_utils_sort_referenced_type_descriptions_in_place(
+      &type_description->referenced_type_descriptions);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_WARN("Could not sort copy of referenced type descriptions for validation");
+    }
+  }
+
+  type_description->referenced_type_descriptions.size += 1;
+  type_description->referenced_type_descriptions.capacity += 1;
+  return RCUTILS_RET_OK;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_append_referenced_type_description(
+  type_description_interfaces__msg__TypeDescription * type_description,
+  type_description_interfaces__msg__TypeDescription * type_description_to_append,
+  bool coerce_to_valid)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_description_to_append, RCUTILS_RET_INVALID_ARGUMENT);
+  if (coerce_to_valid &&
+    !type_description_interfaces_utils_type_description_is_valid(type_description_to_append))
+  {
+    RCUTILS_LOG_ERROR(
+      "`type_description_to_append` is invalid, it must be valid if `coerce_to_valid is true`");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t fini_ret = RCUTILS_RET_ERROR;
+
+  // +1 for the type_description_to_append's main type description
+  size_t extend_size = type_description_to_append->referenced_type_descriptions.size + 1;
+  type_description_interfaces__msg__IndividualTypeDescription * next_ptr = allocator.reallocate(
+    type_description->referenced_type_descriptions.data,
+    type_description->referenced_type_descriptions.size + extend_size,
+    allocator.state);
+  if (next_ptr == NULL) {
+    RCUTILS_LOG_ERROR("Could not realloc type description referenced type descriptions sequence");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  size_t init_reset_size = 0;
+  for (size_t i = 0; i < extend_size; i++) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__init(&next_ptr[i])) {
+      RCUTILS_LOG_ERROR("Could not init new type description referenced type descriptions element");
+      fini_ret = RCUTILS_RET_BAD_ALLOC;
+      goto fail;
+    }
+    init_reset_size += 1;
+  }
+
+  // Copy type_description_to_append's main type description
+  if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+      &type_description_to_append->type_description, next_ptr))
+  {
+    RCUTILS_LOG_ERROR(
+      "Could not copy into new type description referenced type descriptions element");
+    fini_ret = RCUTILS_RET_ERROR;
+    goto fail;
+  }
+
+  // Copy type_description_to_append's referenced type descriptions
+  // There are (extend_size - 1) referenced type descriptions to copy
+  for (size_t i = 1; i < extend_size; i++) {
+    if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+        &type_description_to_append->referenced_type_descriptions.data[i - 1], &next_ptr[i]))
+    {
+      RCUTILS_LOG_ERROR("Could not init new type description referenced type descriptions element");
+      fini_ret = RCUTILS_RET_BAD_ALLOC;
+      goto fail;
+    }
+    init_reset_size += 1;
+  }
+
+  type_description->referenced_type_descriptions.size += extend_size;
+  type_description->referenced_type_descriptions.capacity += extend_size;
+
+  if (coerce_to_valid) {
+    rcutils_ret_t ret =
+      type_description_interfaces_utils_coerce_to_valid_type_description_in_place(type_description);
+    if (ret != RCUTILS_RET_OK) {
+      RCUTILS_LOG_WARN("Could not coerce type description to valid!");
+      return RCUTILS_RET_WARN;
+    }
+  }
+
+  return RCUTILS_RET_OK;
+
+fail:
+  // Attempt to undo changes on failure
+  for (size_t j = 0; j < init_reset_size; j++) {
+    type_description_interfaces__msg__IndividualTypeDescription__fini(&next_ptr[j]);
+  }
+  next_ptr = allocator.reallocate(
+    type_description->referenced_type_descriptions.data,
+    type_description->referenced_type_descriptions.size,
+    allocator.state);
+  if (next_ptr == NULL) {
+    RCUTILS_LOG_ERROR(
+      "Could not shorten type description referenced type descriptions sequence. "
+      "Excess memory will be UNINITIALIZED!");
+    type_description->referenced_type_descriptions.size += extend_size;
+    type_description->referenced_type_descriptions.capacity += extend_size;
+  }
+  return fini_ret;
+}
+
+
+rcutils_ret_t
+type_description_interfaces_utils_get_referenced_type_description_as_type_description(
+  type_description_interfaces__msg__TypeDescription * parent_description,
+  type_description_interfaces__msg__IndividualTypeDescription * referenced_description,
+  type_description_interfaces__msg__TypeDescription ** output_description)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(parent_description, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(referenced_description, RCUTILS_RET_INVALID_ARGUMENT);
+  if (*output_description != NULL) {
+    RCUTILS_LOG_ERROR("`output_description` output argument is not pointing to null");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  *output_description = type_description_interfaces__msg__TypeDescription__create();
+  if (*output_description == NULL) {
+    RCUTILS_LOG_ERROR("Could not create output type description");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  if (!type_description_interfaces__msg__IndividualTypeDescription__copy(
+      referenced_description, &(*output_description)->type_description))
+  {
+    RCUTILS_LOG_ERROR("Could not copy referenced type description into main description");
+    type_description_interfaces__msg__TypeDescription__destroy(*output_description);
+    *output_description = NULL;
+    return RCUTILS_RET_ERROR;
+  }
+
+  if (!type_description_interfaces__msg__IndividualTypeDescription__Sequence__copy(
+      &parent_description->referenced_type_descriptions,
+      &(*output_description)->referenced_type_descriptions))
+  {
+    RCUTILS_LOG_ERROR("Could not copy referenced type descriptions");
+    type_description_interfaces__msg__TypeDescription__destroy(*output_description);
+    *output_description = NULL;
+    return RCUTILS_RET_ERROR;
+  }
+
+  rcutils_ret_t ret =
+    type_description_interfaces_utils_coerce_to_valid_type_description_in_place(*output_description);
+  if (ret != RCUTILS_RET_OK) {
+    RCUTILS_LOG_ERROR("Could not coerce output type description to valid");
+    type_description_interfaces__msg__TypeDescription__destroy(*output_description);
+    *output_description = NULL;
+    return ret;
+  }
+  return RCUTILS_RET_OK;
+}
+
+
+// =================================================================================================
+// DESCRIPTION PRINTING
+// =================================================================================================
+
+void
+type_description_interfaces_utils_print_field_type(
+  const type_description_interfaces__msg__FieldType * field_type)
+{
+  printf(
+    "  [FIELD TYPE]\n"
+    "    type_id: %d\n"
+    "    capacity: %ld\n"
+    "    string_capacity: %ld\n",
+    field_type->type_id, field_type->capacity, field_type->string_capacity);
+
+  if (field_type->nested_type_name.data == NULL) {
+    printf("    nested_type_name: %s\n", field_type->nested_type_name.data);
+  } else {
+    printf("    nested_type_name: \"%s\"\n", field_type->nested_type_name.data);
+  }
+}
+
+
+void
+type_description_interfaces_utils_print_field(const type_description_interfaces__msg__Field * field)
+{
+  printf("[FIELD]\n");
+
+  if (field->name.data == NULL) {
+    printf("  name: %s\n", field->name.data);
+  } else {
+    printf("  name: \"%s\"\n", field->name.data);
+  }
+
+  if (field->default_value.data == NULL) {
+    printf("  default_value: %s\n", field->default_value.data);
+  } else {
+    printf("  default_value: \"%s\"\n", field->default_value.data);
+  }
+
+  type_description_interfaces_utils_print_field_type(&field->type);
+}
+
+
+void
+type_description_interfaces_utils_print_individual_type_description(
+  const type_description_interfaces__msg__IndividualTypeDescription * individual_type_description)
+{
+  printf(
+    "\n[INDIVIDUAL TYPE DESCRIPTION] (Fields: %ld)\n", individual_type_description->fields.size);
+
+  if (individual_type_description->type_name.data == NULL) {
+    printf("  type_name: %s\n", individual_type_description->type_name.data);
+  } else {
+    printf("  type_name: \"%s\"\n", individual_type_description->type_name.data);
+  }
+
+  for (size_t i = 0; i < individual_type_description->fields.size; i++) {
+    type_description_interfaces_utils_print_field(&individual_type_description->fields.data[i]);
+  }
+}
+
+
+void type_description_interfaces_utils_print_type_description(
+  const type_description_interfaces__msg__TypeDescription * type_description)
+{
+  printf("\n\n---\n\n");
+
+  printf(
+    "= [PRINTING TYPE DESCRIPTION] = (Referenced descriptions: %ld)\n",
+    type_description->referenced_type_descriptions.size);
+
+  printf("\n== [MAIN DESCRIPTION] ==\n");
+  type_description_interfaces_utils_print_individual_type_description(
+    &type_description->type_description);
+
+  printf("\n== [REFERENCED DESCRIPTIONS] ==\n");
+  for (size_t i = 0; i < type_description->referenced_type_descriptions.size; i++) {
+    type_description_interfaces_utils_print_individual_type_description(
+      &type_description->referenced_type_descriptions.data[i]);
+  }
+
+  printf("\n---\n\n");
+}
+
+
+void
+type_description_interfaces_utils_print_field_map(const rcutils_hash_map_t * hash_map)
+{
+  char * key;
+  type_description_interfaces__msg__Field * data = NULL;
+  rcutils_ret_t status = rcutils_hash_map_get_next_key_and_data(hash_map, NULL, &key, &data);
+  while (RCUTILS_RET_OK == status) {
+    if (key == NULL) {
+      printf("== KEY: %s ==\n", key);
+    } else {
+      printf("== KEY: \"%s\" ==\n", key);
+    }
+    type_description_interfaces_utils_print_field(data);
+    status = rcutils_hash_map_get_next_key_and_data(hash_map, &key, &key, &data);
+  }
+}
+
+
+void
+type_description_interfaces_utils_print_referenced_type_description_map(
+  const rcutils_hash_map_t * hash_map)
+{
+  char * key;
+  type_description_interfaces__msg__IndividualTypeDescription * data;
+  rcutils_ret_t status = rcutils_hash_map_get_next_key_and_data(hash_map, NULL, &key, &data);
+  while (RCUTILS_RET_OK == status) {
+    if (key == NULL) {
+      printf("== KEY: %s ==\n", key);
+    } else {
+      printf("== KEY: \"%s\" ==\n", key);
+    }
+    type_description_interfaces_utils_print_individual_type_description(data);
+    status = rcutils_hash_map_get_next_key_and_data(hash_map, &key, &key, &data);
+  }
+}

--- a/type_description_interfaces_utils/src/utils.c
+++ b/type_description_interfaces_utils/src/utils.c
@@ -20,10 +20,9 @@
 //                     borrows, whereas the message structs copy.
 //                     So lifetime should be managed by the message structs.
 
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
+#include <type_description_interfaces/msg/field.h>
+#include <type_description_interfaces/msg/individual_type_description.h>
+#include <type_description_interfaces/msg/type_description.h>
 #include <type_description_interfaces_utils/utils.h>
 
 #include <rcutils/logging_macros.h>
@@ -32,9 +31,9 @@
 #include <rcutils/types/hash_map.h>
 #include <rosidl_runtime_c/string_functions.h>
 
-#include <type_description_interfaces/msg/field.h>
-#include <type_description_interfaces/msg/individual_type_description.h>
-#include <type_description_interfaces/msg/type_description.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 
 // Modified from https://stackoverflow.com/questions/4398711/round-to-the-nearest-power-of-two

--- a/type_description_interfaces_utils/test/CMakeLists.txt
+++ b/type_description_interfaces_utils/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+ament_add_gtest(test_utils "test_utils.cpp")
+target_link_libraries(test_utils ${PROJECT_NAME})

--- a/type_description_interfaces_utils/test/test_utils.cpp
+++ b/type_description_interfaces_utils/test/test_utils.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cassert>
+#include <stdlib.h>
+
+#include <cstring>
 #include <gtest/gtest.h>
 
 #include <type_description_interfaces_utils/utils.h>
 
-#include <rcutils/logging_macros.h>
-#include <rcutils/qsort.h>
 #include <rcutils/types/rcutils_ret.h>
 #include <rcutils/types/hash_map.h>
 #include <rosidl_runtime_c/string_functions.h>
@@ -28,32 +28,517 @@
 #include <type_description_interfaces/msg/type_description.h>
 
 
-TEST(Utils, test_construction)
+TEST(TestUtils, test_basic_construction)
 {
-  type_description_interfaces__msg__TypeDescription * desc =
-    type_description_interfaces__msg__TypeDescription__create();
+  const std::string test_name = "test_name";
 
-  type_description_interfaces__msg__Field * field = NULL;
-  type_description_interfaces_utils_create_field(
-    "ROS 2", strlen("ROS 2"), 2,  // Name, Name Length, Type ID
-    0, 0,       // Capacity, String Capacity
-    "", 0,      // Nested Type Name, Nested Type Name Length
-    "", 0,      // Default Value, Default Value Length
-    &field);
+  // TypeDescription
+  {
+    type_description_interfaces__msg__TypeDescription * desc =
+      type_description_interfaces__msg__TypeDescription__create();
+    ASSERT_TRUE(desc);
+    ASSERT_TRUE(
+      rosidl_runtime_c__String__assignn(
+        &desc->type_description.type_name, test_name.c_str(), test_name.size()));
 
-  type_description_interfaces_utils_append_field(
-    &desc->type_description, field);
+    type_description_interfaces__msg__TypeDescription * utils_desc = NULL;
+    EXPECT_EQ(
+      type_description_interfaces_utils_create_type_description(
+        test_name.c_str(),
+        test_name.size(), &utils_desc),
+      RCUTILS_RET_OK);
+    ASSERT_TRUE(utils_desc);
 
-  type_description_interfaces_utils_print_type_description(desc);
+    EXPECT_FALSE(utils_desc->type_description.fields.data);
+    EXPECT_EQ(utils_desc->type_description.fields.size, 0);
+    EXPECT_EQ(utils_desc->type_description.fields.capacity, 0);
 
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    EXPECT_FALSE(utils_desc->referenced_type_descriptions.data);
+    EXPECT_EQ(utils_desc->referenced_type_descriptions.size, 0);
+    EXPECT_EQ(utils_desc->referenced_type_descriptions.capacity, 0);
 
-  rcutils_hash_map_t * hash_map = NULL;
-  type_description_interfaces_utils_get_field_map(
-    &desc->type_description, &allocator, &hash_map);
+    EXPECT_TRUE(type_description_interfaces__msg__TypeDescription__are_equal(desc, utils_desc));
 
-  type_description_interfaces_utils_print_field_map(hash_map);
+    type_description_interfaces__msg__TypeDescription__destroy(desc);
+    type_description_interfaces__msg__TypeDescription__destroy(utils_desc);
+  }
 
-  // TODO(methylDragon): Check to see if finalizing the map causes obtained keys
-  // to segfault
+  // IndividualTypeDescription
+  {
+    type_description_interfaces__msg__IndividualTypeDescription * individual_desc =
+      type_description_interfaces__msg__IndividualTypeDescription__create();
+    ASSERT_TRUE(individual_desc);
+    ASSERT_TRUE(
+      rosidl_runtime_c__String__assignn(
+        &individual_desc->type_name, test_name.c_str(), test_name.size()));
+
+    type_description_interfaces__msg__IndividualTypeDescription * individual_utils_desc = NULL;
+    EXPECT_EQ(
+      type_description_interfaces_utils_create_individual_type_description(
+        test_name.c_str(), test_name.size(), &individual_utils_desc),
+      RCUTILS_RET_OK);
+
+    ASSERT_TRUE(individual_utils_desc);
+
+    EXPECT_FALSE(individual_utils_desc->fields.data);
+    EXPECT_EQ(individual_utils_desc->fields.size, 0);
+    EXPECT_EQ(individual_utils_desc->fields.capacity, 0);
+
+    EXPECT_TRUE(
+      type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+        individual_desc, individual_utils_desc));
+
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(individual_desc);
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(individual_utils_desc);
+  }
+
+  // Field
+  {
+    type_description_interfaces__msg__Field * field =
+      type_description_interfaces__msg__Field__create();
+    ASSERT_TRUE(field);
+    ASSERT_TRUE(
+      rosidl_runtime_c__String__assignn(
+        &field->name, test_name.c_str(), test_name.size()));
+
+    type_description_interfaces__msg__Field * utils_field = NULL;
+    EXPECT_EQ(
+      type_description_interfaces_utils_create_field(
+        test_name.c_str(), test_name.size(), 0,  // Name, Name Length, Type ID
+        0, 0,                                    // Capacity, String Capacity
+        "", 0,                                   // Nested Type Name, Nested Type Name Length
+        "", 0,                                   // Default Value, Default Value Length
+        &utils_field),
+      RCUTILS_RET_OK);
+    ASSERT_TRUE(utils_field);
+
+    EXPECT_TRUE(utils_field->default_value.data);
+
+    EXPECT_EQ(utils_field->default_value.size, 0);
+    EXPECT_EQ(utils_field->default_value.capacity, 1);  // Null terminator
+
+    EXPECT_TRUE(type_description_interfaces__msg__Field__are_equal(field, utils_field));
+
+    type_description_interfaces__msg__Field__destroy(field);
+    type_description_interfaces__msg__Field__destroy(utils_field);
+  }
 }
+
+
+class TestUtilsFixture: public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    type_description_1 = NULL;
+    type_description_interfaces_utils_create_type_description("t1", 2, &type_description_1);
+    ASSERT_TRUE(type_description_1);
+
+    type_description_2 = NULL;
+    type_description_interfaces_utils_create_type_description("t2", 2, &type_description_2);
+    ASSERT_TRUE(type_description_2);
+
+    type_description_3 = NULL;
+    type_description_interfaces_utils_create_type_description("t3", 2, &type_description_3);
+    ASSERT_TRUE(type_description_3);
+
+
+    individual_desc_1 = NULL;
+    type_description_interfaces_utils_create_individual_type_description(
+      "i1", 2, &individual_desc_1);
+    ASSERT_TRUE(individual_desc_1);
+
+    individual_desc_2 = NULL;
+    type_description_interfaces_utils_create_individual_type_description(
+      "i2", 2, &individual_desc_2);
+    ASSERT_TRUE(individual_desc_2);
+
+    individual_desc_3 = NULL;
+    type_description_interfaces_utils_create_individual_type_description(
+      "i3", 2, &individual_desc_3);
+    ASSERT_TRUE(individual_desc_3);
+
+    empty_individual_desc = NULL;
+    type_description_interfaces_utils_create_individual_type_description(
+      "empty", 5, &empty_individual_desc);
+    ASSERT_TRUE(empty_individual_desc);
+
+
+    field_1 = NULL;  // Nested
+    type_description_interfaces_utils_create_field(
+      "f1", 2, 1,                 // Name, Name Length, Type ID
+      0, 0,                       // Capacity, String Capacity
+      "empty", 5,                 // Nested Type Name, Nested Type Name Length
+      "", 0,                      // Default Value, Default Value Length
+      &field_1);
+    ASSERT_TRUE(field_1);
+
+    field_2 = NULL;
+    type_description_interfaces_utils_create_field(
+      "f2", 2, 2,  // Name, Name Length, Type ID
+      0, 0, "", 0, "", 0, &field_2);
+    ASSERT_TRUE(field_2);
+
+    field_3 = NULL;
+    type_description_interfaces_utils_create_field(
+      "f3", 2, 3,  // Name, Name Length, Type ID
+      0, 0, "", 0, "", 0, &field_3);
+    ASSERT_TRUE(field_3);
+  }
+
+  void TearDown()
+  {
+    type_description_interfaces__msg__TypeDescription__destroy(type_description_1);
+    type_description_interfaces__msg__TypeDescription__destroy(type_description_2);
+    type_description_interfaces__msg__TypeDescription__destroy(type_description_3);
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(individual_desc_1);
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(individual_desc_2);
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(individual_desc_3);
+    type_description_interfaces__msg__IndividualTypeDescription__destroy(empty_individual_desc);
+    type_description_interfaces__msg__Field__destroy(field_1);
+    type_description_interfaces__msg__Field__destroy(field_2);
+    type_description_interfaces__msg__Field__destroy(field_3);
+  }
+
+  type_description_interfaces__msg__TypeDescription * type_description_1;
+  type_description_interfaces__msg__TypeDescription * type_description_2;
+  type_description_interfaces__msg__TypeDescription * type_description_3;
+
+  type_description_interfaces__msg__IndividualTypeDescription * individual_desc_1;
+  type_description_interfaces__msg__IndividualTypeDescription * individual_desc_2;
+  type_description_interfaces__msg__IndividualTypeDescription * individual_desc_3;
+  type_description_interfaces__msg__IndividualTypeDescription * empty_individual_desc;
+
+  type_description_interfaces__msg__Field * field_1;
+  type_description_interfaces__msg__Field * field_2;
+  type_description_interfaces__msg__Field * field_3;
+
+  rcutils_ret_t ret = RCUTILS_RET_ERROR;
+};
+
+
+TEST_F(TestUtilsFixture, test_appends_and_advanced_construction)
+{
+  // FIELD APPEND
+  EXPECT_EQ(individual_desc_1->fields.size, 0);
+  EXPECT_EQ(individual_desc_1->fields.capacity, 0);
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_1);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(individual_desc_1->fields.size, 1);
+  EXPECT_EQ(individual_desc_1->fields.capacity, 1);
+
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_2);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(individual_desc_1->fields.size, 2);
+  EXPECT_EQ(individual_desc_1->fields.capacity, 2);
+
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_3);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(individual_desc_1->fields.size, 3);
+  EXPECT_EQ(individual_desc_1->fields.capacity, 3);
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__Field__are_equal(
+      &individual_desc_1->fields.data[0], field_1));
+  EXPECT_TRUE(
+    type_description_interfaces__msg__Field__are_equal(
+      &individual_desc_1->fields.data[1], field_2));
+  EXPECT_TRUE(
+    type_description_interfaces__msg__Field__are_equal(
+      &individual_desc_1->fields.data[2], field_3));
+
+
+  // REFERENCED INDIVIDUAL TYPE DESCRIPTION APPEND
+  // Append out of order
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.size, 0);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.capacity, 0);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_1, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.size, 1);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.capacity, 1);
+
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_3, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.size, 2);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.capacity, 2);
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_1->referenced_type_descriptions.data[0], individual_desc_1));
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_1->referenced_type_descriptions.data[1], individual_desc_3));
+
+
+  // Append and Sort
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_2, true);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.size, 3);
+  EXPECT_EQ(type_description_1->referenced_type_descriptions.capacity, 3);
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_1->referenced_type_descriptions.data[0], individual_desc_1));
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_1->referenced_type_descriptions.data[1], individual_desc_2));
+
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_1->referenced_type_descriptions.data[2], individual_desc_3));
+
+
+  // REFERENCED TYPE DESCRIPTION APPEND
+  // Naive recursive append
+  EXPECT_EQ(type_description_2->referenced_type_descriptions.size, 0);
+  EXPECT_EQ(type_description_2->referenced_type_descriptions.capacity, 0);
+  ret = type_description_interfaces_utils_append_referenced_type_description(
+    type_description_2, type_description_1, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  EXPECT_EQ(type_description_2->referenced_type_descriptions.size, 4);
+  EXPECT_EQ(type_description_2->referenced_type_descriptions.capacity, 4);
+
+
+  // Recursive append with coercion to valid
+  EXPECT_EQ(
+    type_description_interfaces_utils_append_field(
+      &type_description_1->type_description, field_1),
+    RCUTILS_RET_OK);
+
+  EXPECT_EQ(
+    type_description_interfaces_utils_append_field(
+      &type_description_3->type_description, field_1),
+    RCUTILS_RET_OK);
+
+  // Deliberately invalid
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.size, 0);
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.capacity, 0);
+  ASSERT_EQ(
+    type_description_interfaces_utils_append_referenced_type_description(
+      type_description_3, type_description_1, true),
+    RCUTILS_RET_WARN);
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.size, 4);
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.capacity, 4);
+
+  // With the append of the empty ref description, it should work now
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, empty_individual_desc, true);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(
+    type_description_interfaces_utils_append_referenced_type_description(
+      type_description_3, type_description_1, true),
+    RCUTILS_RET_OK);
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.size, 1);
+  EXPECT_EQ(type_description_3->referenced_type_descriptions.capacity, 1);
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      &type_description_3->referenced_type_descriptions.data[0], empty_individual_desc));
+
+
+  // Get referenced type as its own full description
+  // Naively (naive append of ref types)
+  type_description_interfaces__msg__TypeDescription * subset_desc = NULL;
+  type_description_interfaces_utils_get_referenced_type_description_as_type_description(
+    type_description_1,  // Refs: i1, i2, i3, empty
+    individual_desc_1,   // Depends on ref: "empty"
+    &subset_desc,
+    false);              // No coercion to valid
+  EXPECT_EQ(subset_desc->referenced_type_descriptions.size, 4);
+  EXPECT_EQ(subset_desc->referenced_type_descriptions.capacity, 4);
+  EXPECT_FALSE(type_description_interfaces__msg__TypeDescription__are_equal(
+    type_description_1, subset_desc));
+  type_description_interfaces__msg__TypeDescription__destroy(subset_desc);
+
+  type_description_interfaces__msg__TypeDescription * subset_desc_2 = NULL;
+  type_description_interfaces_utils_get_referenced_type_description_as_type_description(
+    type_description_1,  // Refs: i1, i2, i3, empty
+    individual_desc_1,   // Depends on ref: "empty"
+    &subset_desc_2,
+    true);              // Coercion to valid
+  EXPECT_EQ(subset_desc_2->referenced_type_descriptions.size, 1);
+  EXPECT_EQ(subset_desc_2->referenced_type_descriptions.capacity, 1);
+  EXPECT_FALSE(type_description_interfaces__msg__TypeDescription__are_equal(
+    type_description_1, subset_desc_2));
+  EXPECT_TRUE(type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+    &subset_desc_2->referenced_type_descriptions.data[0], empty_individual_desc));
+  // type_description_interfaces_utils_print_type_description(type_description_1);
+  // type_description_interfaces_utils_print_type_description(subset_desc_2);
+  type_description_interfaces__msg__TypeDescription__destroy(subset_desc_2);
+}
+
+
+TEST_F(TestUtilsFixture, test_find)
+{
+  // Find Field
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_1);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_2);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_3);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  type_description_interfaces__msg__Field * find_field = NULL;
+  ret = type_description_interfaces_utils_find_field(&individual_desc_1->fields, "a", &find_field);
+  EXPECT_EQ(ret, RCUTILS_RET_NOT_FOUND);
+  EXPECT_FALSE(find_field);
+
+  ret = type_description_interfaces_utils_find_field(&individual_desc_1->fields, "f3", &find_field);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_TRUE(type_description_interfaces__msg__Field__are_equal(find_field, field_3));
+
+  // Find Referenced Type Description
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_1, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_2, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_3, true);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  type_description_interfaces__msg__IndividualTypeDescription * find_desc = NULL;
+  ret = type_description_interfaces_utils_find_referenced_type_description(
+    &type_description_1->referenced_type_descriptions, "a", &find_desc);
+  EXPECT_EQ(ret, RCUTILS_RET_NOT_FOUND);
+  EXPECT_FALSE(find_desc);
+
+  ret = type_description_interfaces_utils_find_referenced_type_description(
+    &type_description_1->referenced_type_descriptions, "i3", &find_desc);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__are_equal(
+      find_desc, individual_desc_3));
+}
+
+
+TEST_F(TestUtilsFixture, test_maps)
+{
+  rcutils_hash_map_t * hash_map = NULL;
+  rcutils_hash_map_t * ref_types_hash_map = NULL;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  size_t map_length;
+
+  // Field map when empty
+  ret = type_description_interfaces_utils_get_field_map(individual_desc_1, &allocator, &hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 0);
+  ASSERT_EQ(rcutils_hash_map_fini(hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(hash_map, allocator.state);
+  hash_map = NULL;
+
+  // Field map when populated
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_1);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_2);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_field(individual_desc_1, field_3);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ret = type_description_interfaces_utils_get_field_map(individual_desc_1, &allocator, &hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 3);
+  ASSERT_EQ(rcutils_hash_map_fini(hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(hash_map, allocator.state);
+  hash_map = NULL;
+
+
+  // Ref type map when empty
+  ret = type_description_interfaces_utils_get_referenced_type_description_map(
+    &type_description_1->referenced_type_descriptions, &allocator, &hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 0);
+  ASSERT_EQ(rcutils_hash_map_fini(hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(hash_map, allocator.state);
+  hash_map = NULL;
+
+  // Ref type map when populated
+  // Also we set up the next test block (for testing the necessary map)
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_1, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_2, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, individual_desc_3, false);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+  ret = type_description_interfaces_utils_append_referenced_individual_type_description(
+    type_description_1, empty_individual_desc, true);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ret = type_description_interfaces_utils_get_referenced_type_description_map(
+    &type_description_1->referenced_type_descriptions, &allocator, &ref_types_hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(ref_types_hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 4);
+
+
+  // Necessary ref type map when empty
+  ret = type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+    &type_description_1->type_description,
+    ref_types_hash_map,
+    &allocator,
+    &hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 0);
+  ASSERT_EQ(rcutils_hash_map_fini(hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(hash_map, allocator.state);
+  hash_map = NULL;
+
+  // Necessary ref type map when populated
+  ret = type_description_interfaces_utils_append_field(
+    &type_description_1->type_description, field_1);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  // Expect failure since empty ref type not added yet
+  ret = type_description_interfaces_utils_get_necessary_referenced_type_descriptions_map(
+    &type_description_1->type_description,
+    ref_types_hash_map,
+    &allocator,
+    &hash_map);
+  ASSERT_EQ(ret, RCUTILS_RET_OK);
+
+  ASSERT_EQ(rcutils_hash_map_get_size(hash_map, &map_length), RCUTILS_RET_OK);
+  ASSERT_EQ(map_length, 1);
+  ASSERT_EQ(rcutils_hash_map_fini(hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(hash_map, allocator.state);
+  hash_map = NULL;
+
+
+  // Ref type map to sequence
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence * seq = NULL;
+  ret = type_description_interfaces_utils_copy_init_sequence_from_referenced_type_descriptions_map(
+    ref_types_hash_map, &seq, true);
+  EXPECT_EQ(ret, RCUTILS_RET_OK);
+  EXPECT_TRUE(
+    type_description_interfaces__msg__IndividualTypeDescription__Sequence__are_equal(
+      &type_description_1->referenced_type_descriptions, seq));
+
+
+  type_description_interfaces__msg__IndividualTypeDescription__Sequence__destroy(seq);
+
+  ASSERT_EQ(rcutils_hash_map_fini(ref_types_hash_map), RCUTILS_RET_OK);
+  allocator.deallocate(ref_types_hash_map, allocator.state);
+  ref_types_hash_map = NULL;
+}
+
+// TODO(methylDragon)
+// TEST(Utils, test_prints)  <-- deferred because it's utility
+// TEST(Utils, test_validity)  <-- This is technically implicitly tested with appends with coercion

--- a/type_description_interfaces_utils/test/test_utils.cpp
+++ b/type_description_interfaces_utils/test/test_utils.cpp
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
-
-#include <cstring>
-#include <gtest/gtest.h>
-
+#include <type_description_interfaces/msg/field.h>
+#include <type_description_interfaces/msg/individual_type_description.h>
+#include <type_description_interfaces/msg/type_description.h>
 #include <type_description_interfaces_utils/utils.h>
 
 #include <rcutils/types/rcutils_ret.h>
 #include <rcutils/types/hash_map.h>
 #include <rosidl_runtime_c/string_functions.h>
 
-#include <type_description_interfaces/msg/field.h>
-#include <type_description_interfaces/msg/individual_type_description.h>
-#include <type_description_interfaces/msg/type_description.h>
+#include <stdlib.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
 
 
 TEST(TestUtils, test_basic_construction)

--- a/type_description_interfaces_utils/test/test_utils.cpp
+++ b/type_description_interfaces_utils/test/test_utils.cpp
@@ -1,0 +1,59 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <gtest/gtest.h>
+
+#include <type_description_interfaces_utils/utils.h>
+
+#include <rcutils/logging_macros.h>
+#include <rcutils/qsort.h>
+#include <rcutils/types/rcutils_ret.h>
+#include <rcutils/types/hash_map.h>
+#include <rosidl_runtime_c/string_functions.h>
+
+#include <type_description_interfaces/msg/field.h>
+#include <type_description_interfaces/msg/individual_type_description.h>
+#include <type_description_interfaces/msg/type_description.h>
+
+
+TEST(Utils, test_construction)
+{
+  type_description_interfaces__msg__TypeDescription * desc =
+    type_description_interfaces__msg__TypeDescription__create();
+
+  type_description_interfaces__msg__Field * field = NULL;
+  type_description_interfaces_utils_create_field(
+    "ROS 2", strlen("ROS 2"), 2,  // Name, Name Length, Type ID
+    0, 0,       // Capacity, String Capacity
+    "", 0,      // Nested Type Name, Nested Type Name Length
+    "", 0,      // Default Value, Default Value Length
+    &field);
+
+  type_description_interfaces_utils_append_field(
+    &desc->type_description, field);
+
+  type_description_interfaces_utils_print_type_description(desc);
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  rcutils_hash_map_t * hash_map = NULL;
+  type_description_interfaces_utils_get_field_map(
+    &desc->type_description, &allocator, &hash_map);
+
+  type_description_interfaces_utils_print_field_map(hash_map);
+
+  // TODO(methylDragon): Check to see if finalizing the map causes obtained keys
+  // to segfault
+}


### PR DESCRIPTION
This PR is part of the runtime interface reflection subscription feature of REP-2011: https://github.com/ros2/ros2/issues/1374

# Description
This PR adds a utilities library for manipulating and constructing the C structs generated by `type_description_interfaces`, including:
- Handy print functions
- Hash map construction
- Sorting and pruning of referenced types (to prep them for hashing)
- Checking of type validity
- Appending fields and referenced type descriptions
- Creating TypeDescriptions from referenced type descriptions (description subsetting)

I also pre-generate the `type_description_interfaces` sources and headers to create a new package (`type_description_interfaces_static`) to remove a dependency cycle downstream. (That's why there are so many lines.)

~~I haven't implemented tests yet, so some memory management issues/segfaults are expected. I'm working on it, but I am wary of spending too much time getting 100% coverage because we're trying to meet the deadline for feature freeze...~~

I've implemented a bunch of tests and I'm fairly confident that most of the core functionalities work as expected now, so I'm going to mark the PR as ready to review.

[Asan](https://github.com/colcon/colcon-sanitizer-reports) runs green too!
```shell
clear && \
colcon build --packages-select type_description_interfaces_utils \
  --build-base=build-asan --install-base=install-asan \
  --cmake-args -DOSRF_TESTING_TOOLS_CPP_DISABLE_MEMORY_TOOLS=ON \
               -DINSTALL_EXAMPLES=OFF -DSECURITY=ON --no-warn-unused-cli \
               -DCMAKE_BUILD_TYPE=Debug \
  --mixin asan-gcc && \
colcon test --build-base=build-asan --install-base=install-asan \
  --event-handlers sanitizer_report+ --packages-select type_description_interfaces_utils
```

There are some less important tests waiting to be written (printing), and some tests that are already implicitly covered by other tests (but are not explicit yet.)

# TODO
- [ ] More minor tests
- [ ] 100% docstring coverage

# Open Questions
- This only operates on the C version of the type_description_interfaces struct... Do I need to write a C++ version? (Is there a way to convert between the two versions of the message, or are they otherwise interchangeable?)
  - Perhaps that C++ utils library would just have a conversion function, since we know the layout of the struct already???
- Should this be `type_description_interfaces_utils_c` instead? :grimacing: