### PR TITLE
Add a constant value for failing to set an undeclared parameter

### DIFF
--- a/rcl_interfaces/msg/SetParametersResult.msg
+++ b/rcl_interfaces/msg/SetParametersResult.msg
@@ -10,4 +10,4 @@ string reason
 # is only allowed to set values for declared parameters, and the parameter that
 # the request was trying to set not declared by the node. Use the ListParameters
 # service to see which parameters are declared.
-string REASON_UNDECLARED_NOT_ALLOWED = "Parameter is not declared by the node, which only allows declared parameters"
+string REASON_UNDECLARED_NOT_ALLOWED = "parameter is not declared by the node, which only allows declared parameters"

--- a/rcl_interfaces/msg/SetParametersResult.msg
+++ b/rcl_interfaces/msg/SetParametersResult.msg
@@ -5,3 +5,9 @@ bool successful
 # Reason why the setting was a failure. On success, the contents of this field
 # are undefined.  This should only be used for logging and user interfaces.
 string reason
+
+# This reason for failing to set a parameter value should be given when the node
+# is only allowed to set values for declared parameters, and the parameter that
+# the request was trying to set not declared by the node. Use the ListParameters
+# service to see which parameters are declared.
+string REASON_UNDECLARED_NOT_ALLOWED = "Parameter is not declared by the node, which only allows declared parameters"


### PR DESCRIPTION
Related to [a discussion](https://github.com/ros2/rclcpp/issues/2512) about improving how rclcpp and rclpy comply with the parameter service documentation.

This PR is needed by https://github.com/ros2/rclcpp/pull/2515