### PR TITLE
Added service_msgs dependency to solve a build error for a ROS 2 Jazzy workspace built from source

### DIFF
--- a/rcl_interfaces/CMakeLists.txt
+++ b/rcl_interfaces/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(service_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FloatingPointRange.msg"

--- a/rcl_interfaces/package.xml
+++ b/rcl_interfaces/package.xml
@@ -20,6 +20,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>builtin_interfaces</depend>
+  <depend>service_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
As part of a 3d robotics simulator, I put together a [ROS 2 Jazzy workspace](https://github.com/Mechazo11/ubuntu22_jazzy_ws) built from source files in Ubuntu 22.04.

When building all pertinent packages along with ```rcl_interfaces```, I ran into a dependency issue related to ```service_msgs```. This issue might have been reported last year in this answers.ros.org post: https://answers.ros.org/question/413630/issues-with-service_msgs/

I was able to solve this problem by simply adding the ```service_msgs``` dependency into `CmakeLists.txt` and `package.xml` files for the ```rcl_interfaces``` package and then tested to ensure it built correctly.