### PR TITLE
Explicit Undeclareing parameter descriptor feild

### DIFF
--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -24,6 +24,9 @@ bool read_only false
 # If true, the parameter is allowed to change type.
 bool dynamic_typing false
 
+#if true, the parameter is allowed to be undeclared
+bool undeclarable false
+
 # If any of the following sequences are not empty, then the constraint inside of
 # them apply to this parameter.
 #

--- a/rcl_interfaces/msg/ParameterDescriptor.msg
+++ b/rcl_interfaces/msg/ParameterDescriptor.msg
@@ -21,7 +21,7 @@ string additional_constraints
 # If 'true' then the value cannot change after it has been initialized.
 bool read_only false
 
-# If true, the parameter is allowed to change type.
+# If true, the parameter is allowed to change type and be undeclared.
 bool dynamic_typing false
 
 #if true, the parameter is allowed to be undeclared


### PR DESCRIPTION
Currently for node parameters to be undeclared they must also be dynamically typed. however I think that there are cases where statically typed params should be undeclared and dynamically typed params should be able to be removed. This adds another field in the parameter descriptor message that is by default false that represents whether or not a parameter is able to be undeclared.  