### PR TITLE
Added test messages with keys

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -28,6 +28,9 @@ rosidl_generate_interfaces(test_msgs
   ${test_interface_files_ACTION_FILES}
   ${test_interface_files_IDL_FILES}
   "msg/Builtins.msg"
+  "msg/KeyedString.idl"
+  "msg/NonKeyedWithNestedKey.idl"
+  "msg/ComplexNestedKey.idl"
   "action/NestedMessage.action"
   DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS

--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -28,6 +28,7 @@ rosidl_generate_interfaces(test_msgs
   ${test_interface_files_ACTION_FILES}
   ${test_interface_files_IDL_FILES}
   "msg/Builtins.msg"
+  "msg/KeyedLong.idl"
   "msg/KeyedString.idl"
   "msg/NonKeyedWithNestedKey.idl"
   "msg/ComplexNestedKey.idl"

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -32,6 +32,7 @@
 #include "test_msgs/msg/constants.hpp"
 #include "test_msgs/msg/defaults.hpp"
 #include "test_msgs/msg/empty.hpp"
+#include "test_msgs/msg/keyed_string.hpp"
 #include "test_msgs/msg/multi_nested.hpp"
 #include "test_msgs/msg/nested.hpp"
 #include "test_msgs/msg/strings.hpp"
@@ -575,6 +576,25 @@ get_messages_wstrings()
   {
     auto msg = std::make_shared<test_msgs::msg::WStrings>();
     msg->wstring_value = u"ハローワールド";  // "Hello world" in Japanese
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+static inline std::vector<test_msgs::msg::KeyedString::SharedPtr>
+get_messages_keyed_string()
+{
+  std::vector<test_msgs::msg::KeyedString::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_msgs::msg::KeyedString>();
+    msg->key = "key_1";
+    msg->value = "value_1";
+    messages.push_back(msg);
+  }
+  {
+    auto msg = std::make_shared<test_msgs::msg::KeyedString>();
+    msg->key = "key_2";
+    msg->value = "value_2";
     messages.push_back(msg);
   }
   return messages;

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -29,6 +29,7 @@
 #include "test_msgs/msg/bounded_plain_sequences.hpp"
 #include "test_msgs/msg/bounded_sequences.hpp"
 #include "test_msgs/msg/builtins.hpp"
+#include "test_msgs/msg/complex_nested_key.hpp"
 #include "test_msgs/msg/constants.hpp"
 #include "test_msgs/msg/defaults.hpp"
 #include "test_msgs/msg/empty.hpp"
@@ -610,6 +611,21 @@ get_messages_non_keyed_with_nested_key()
     auto msg = std::make_shared<test_msgs::msg::NonKeyedWithNestedKey>();
     msg->nested_data = *keyed_string_msg;
     msg->some_int = -1;
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+static inline std::vector<test_msgs::msg::ComplexNestedKey::SharedPtr>
+get_messages_complex_nested_key()
+{
+  std::vector<test_msgs::msg::ComplexNestedKey::SharedPtr> messages;
+  auto non_keyed_with_nested_key_msgs = get_messages_non_keyed_with_nested_key();
+  for (auto nested_msg : non_keyed_with_nested_key_msgs) {
+    auto msg = std::make_shared<test_msgs::msg::ComplexNestedKey>();
+    msg->nested_keys = *nested_msg;
+    msg->uint32_key = 3u;
+    msg->float64_value = 1.125;
     messages.push_back(msg);
   }
   return messages;

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -35,6 +35,7 @@
 #include "test_msgs/msg/keyed_string.hpp"
 #include "test_msgs/msg/multi_nested.hpp"
 #include "test_msgs/msg/nested.hpp"
+#include "test_msgs/msg/non_keyed_with_nested_key.hpp"
 #include "test_msgs/msg/strings.hpp"
 #include "test_msgs/msg/unbounded_sequences.hpp"
 #include "test_msgs/msg/w_strings.hpp"
@@ -595,6 +596,20 @@ get_messages_keyed_string()
     auto msg = std::make_shared<test_msgs::msg::KeyedString>();
     msg->key = "key_2";
     msg->value = "value_2";
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+static inline std::vector<test_msgs::msg::NonKeyedWithNestedKey::SharedPtr>
+get_messages_non_keyed_with_nested_key()
+{
+  std::vector<test_msgs::msg::NonKeyedWithNestedKey::SharedPtr> messages;
+  auto keyed_string_msgs = get_messages_keyed_string();
+  for (auto keyed_string_msg : keyed_string_msgs) {
+    auto msg = std::make_shared<test_msgs::msg::NonKeyedWithNestedKey>();
+    msg->nested_data = *keyed_string_msg;
+    msg->some_int = -1;
     messages.push_back(msg);
   }
   return messages;

--- a/test_msgs/include/test_msgs/message_fixtures.hpp
+++ b/test_msgs/include/test_msgs/message_fixtures.hpp
@@ -33,6 +33,7 @@
 #include "test_msgs/msg/constants.hpp"
 #include "test_msgs/msg/defaults.hpp"
 #include "test_msgs/msg/empty.hpp"
+#include "test_msgs/msg/keyed_long.hpp"
 #include "test_msgs/msg/keyed_string.hpp"
 #include "test_msgs/msg/multi_nested.hpp"
 #include "test_msgs/msg/nested.hpp"
@@ -578,6 +579,25 @@ get_messages_wstrings()
   {
     auto msg = std::make_shared<test_msgs::msg::WStrings>();
     msg->wstring_value = u"ハローワールド";  // "Hello world" in Japanese
+    messages.push_back(msg);
+  }
+  return messages;
+}
+
+static inline std::vector<test_msgs::msg::KeyedLong::SharedPtr>
+get_messages_keyed_long()
+{
+  std::vector<test_msgs::msg::KeyedLong::SharedPtr> messages;
+  {
+    auto msg = std::make_shared<test_msgs::msg::KeyedLong>();
+    msg->key = 1;
+    msg->value = 1;
+    messages.push_back(msg);
+  }
+  {
+    auto msg = std::make_shared<test_msgs::msg::KeyedLong>();
+    msg->key = 2;
+    msg->value = 2;
     messages.push_back(msg);
   }
   return messages;

--- a/test_msgs/msg/ComplexNestedKey.idl
+++ b/test_msgs/msg/ComplexNestedKey.idl
@@ -1,0 +1,11 @@
+#include "test_msgs/msg/NonKeyedWithNestedKey.idl"
+
+module test_msgs{
+  module msg {
+    struct ComplexNestedKey {
+      @key uint32 uint32_key;
+      @key test_msgs::msg::NonKeyedWithNestedKey nested_keys;
+      double float64_value;
+    };
+  };
+};

--- a/test_msgs/msg/KeyedLong.idl
+++ b/test_msgs/msg/KeyedLong.idl
@@ -1,0 +1,8 @@
+module test_msgs{
+  module msg {
+    struct KeyedLong {
+      @key long key;
+      long value;
+    };
+  };
+};

--- a/test_msgs/msg/KeyedString.idl
+++ b/test_msgs/msg/KeyedString.idl
@@ -1,0 +1,8 @@
+module test_msgs{
+  module msg {
+    struct KeyedString {
+      @key string key;
+      string value;
+    };
+  };
+};

--- a/test_msgs/msg/NonKeyedWithNestedKey.idl
+++ b/test_msgs/msg/NonKeyedWithNestedKey.idl
@@ -1,0 +1,10 @@
+#include "test_msgs/msg/KeyedString.idl"
+
+module test_msgs{
+  module msg {
+    struct NonKeyedWithNestedKey {
+      test_msgs::msg::KeyedString nested_data;
+      int32 some_int;
+    };
+  };
+};

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -20,6 +20,7 @@ from test_msgs.msg import Builtins
 from test_msgs.msg import Constants
 from test_msgs.msg import Defaults
 from test_msgs.msg import Empty
+from test_msgs.msg import KeyedString
 from test_msgs.msg import MultiNested
 from test_msgs.msg import Nested
 from test_msgs.msg import Strings
@@ -395,6 +396,22 @@ def get_msg_wstrings():
     return msgs
 
 
+def get_msg_keyed_string():
+    msgs = []
+
+    msg = KeyedString()
+    msg.key = 'key_1'
+    msg.value = 'value_1'
+    msgs.append(msg)
+
+    msg = KeyedString()
+    msg.key = 'key_2'
+    msg.value = 'value_2'
+    msgs.append(msg)
+
+    return msgs
+
+
 def get_test_msg(message_name):
     if 'Builtins' == message_name:
         msg = get_msg_builtins()
@@ -422,6 +439,8 @@ def get_test_msg(message_name):
         msg = get_msg_multi_nested()
     elif 'WStrings' == message_name:
         msg = get_msg_wstrings()
+    elif 'KeyedString' == message_name:
+        msg = get_msg_keyed_string()
     else:
         raise NotImplementedError
     return msg

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -23,6 +23,7 @@ from test_msgs.msg import Empty
 from test_msgs.msg import KeyedString
 from test_msgs.msg import MultiNested
 from test_msgs.msg import Nested
+from test_msgs.msg import NonKeyedWithNestedKey
 from test_msgs.msg import Strings
 from test_msgs.msg import UnboundedSequences
 from test_msgs.msg import WStrings
@@ -412,6 +413,19 @@ def get_msg_keyed_string():
     return msgs
 
 
+def get_msg_non_keyed_with_nested_key():
+    msgs = []
+
+    keyed_string_msgs = get_msg_keyed_string()
+    for keyed_string_msg in keyed_string_msgs:
+        msg = NonKeyedWithNestedKey()
+        msg.nested_data = keyed_string_msg
+        msg.some_int = -1
+        msgs.append(msg)
+
+    return msgs
+
+
 def get_test_msg(message_name):
     if 'Builtins' == message_name:
         msg = get_msg_builtins()
@@ -441,6 +455,8 @@ def get_test_msg(message_name):
         msg = get_msg_wstrings()
     elif 'KeyedString' == message_name:
         msg = get_msg_keyed_string()
+    elif 'NonKeyedWithNestedKey' == message_name:
+        msg = get_msg_non_keyed_with_nested_key()
     else:
         raise NotImplementedError
     return msg

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -17,6 +17,7 @@ from test_msgs.msg import BasicTypes
 from test_msgs.msg import BoundedPlainSequences
 from test_msgs.msg import BoundedSequences
 from test_msgs.msg import Builtins
+from test_msgs.msg import ComplexNestedKey
 from test_msgs.msg import Constants
 from test_msgs.msg import Defaults
 from test_msgs.msg import Empty
@@ -426,6 +427,20 @@ def get_msg_non_keyed_with_nested_key():
     return msgs
 
 
+def get_msg_complex_nested_key():
+    msgs = []
+
+    non_keyed_with_nested_key_msgs = get_msg_non_keyed_with_nested_key()
+    for nested_msg in non_keyed_with_nested_key_msgs:
+        msg = ComplexNestedKey()
+        msg.nested_keys = nested_msg
+        msg.uint32_key = 3
+        msg.float64_value = 1.125
+        msgs.append(msg)
+
+    return msgs
+
+
 def get_test_msg(message_name):
     if 'Builtins' == message_name:
         msg = get_msg_builtins()
@@ -457,6 +472,8 @@ def get_test_msg(message_name):
         msg = get_msg_keyed_string()
     elif 'NonKeyedWithNestedKey' == message_name:
         msg = get_msg_non_keyed_with_nested_key()
+    elif 'ComplexNestedKey' == message_name:
+        msg = get_msg_complex_nested_key()
     else:
         raise NotImplementedError
     return msg

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -21,6 +21,7 @@ from test_msgs.msg import ComplexNestedKey
 from test_msgs.msg import Constants
 from test_msgs.msg import Defaults
 from test_msgs.msg import Empty
+from test_msgs.msg import KeyedLong
 from test_msgs.msg import KeyedString
 from test_msgs.msg import MultiNested
 from test_msgs.msg import Nested
@@ -397,6 +398,20 @@ def get_msg_wstrings():
 
     return msgs
 
+def get_msg_keyed_long():
+    msgs = []
+
+    msg = KeyedLong()
+    msg.key = 1
+    msg.value = 1
+    msgs.append(msg)
+
+    msg = KeyedLong()
+    msg.key = 2
+    msg.value = 2
+    msgs.append(msg)
+
+    return msgs
 
 def get_msg_keyed_string():
     msgs = []
@@ -468,6 +483,8 @@ def get_test_msg(message_name):
         msg = get_msg_multi_nested()
     elif 'WStrings' == message_name:
         msg = get_msg_wstrings()
+    elif 'KeyedLong' == message_name:
+        msg = get_msg_keyed_long()
     elif 'KeyedString' == message_name:
         msg = get_msg_keyed_string()
     elif 'NonKeyedWithNestedKey' == message_name:

--- a/test_msgs/src/test_msgs/message_fixtures.py
+++ b/test_msgs/src/test_msgs/message_fixtures.py
@@ -398,6 +398,7 @@ def get_msg_wstrings():
 
     return msgs
 
+
 def get_msg_keyed_long():
     msgs = []
 
@@ -412,6 +413,7 @@ def get_msg_keyed_long():
     msgs.append(msg)
 
     return msgs
+
 
 def get_msg_keyed_string():
     msgs = []


### PR DESCRIPTION
This adds some messages to `test_msgs` package that test the behavior regarding @key annotations. An extra message has been added in comparison to https://github.com/ros2/rcl_interfaces/pull/162 to test a short key.

Part of https://github.com/ros2/ros2/issues/1538.