### PR TITLE
Add info to duration message and time message comments

### DIFF
--- a/builtin_interfaces/msg/Duration.msg
+++ b/builtin_interfaces/msg/Duration.msg
@@ -2,7 +2,7 @@
 # Messages of this datatype are of ROS Time following this design:
 # https://design.ros2.org/articles/clock_and_time.html
 
-# Seconds component, range is valid over any possible int32 value.
+# The seconds component, valid over all int32 values.
 int32 sec
 
 # The nanoseconds component, valid in the range [0, 1e9), to be added to the seconds component. 

--- a/builtin_interfaces/msg/Duration.msg
+++ b/builtin_interfaces/msg/Duration.msg
@@ -5,5 +5,8 @@
 # Seconds component, range is valid over any possible int32 value.
 int32 sec
 
-# Nanoseconds component in the range of [0, 1e9).
+# The nanoseconds component, valid in the range [0, 1e9), to be added to the seconds component. 
+# e.g.
+# The duration -1.7 seconds is represented as {sec: -2, nanosec: 3e8}
+# The duration 1.7 seconds is represented as {sec: 1, nanosec: 7e8}
 uint32 nanosec

--- a/builtin_interfaces/msg/Time.msg
+++ b/builtin_interfaces/msg/Time.msg
@@ -4,5 +4,8 @@
 # The seconds component, valid over all int32 values.
 int32 sec
 
-# The nanoseconds component, valid in the range [0, 1e9).
+# The nanoseconds component, valid in the range [0, 1e9), to be added to the seconds component. 
+# e.g.
+# The time -1.7 seconds is represented as {sec: -2, nanosec: 3e8}
+# The time 1.7 seconds is represented as {sec: 1, nanosec: 7e8}
 uint32 nanosec


### PR DESCRIPTION
Closes #175

Makes comments for duration messages and time messages more clear, and adds examples for the message types. 