### PR TITLE
Use builtin_interfaces/Time for TransitionEvent stamp

### DIFF
--- a/lifecycle_msgs/CMakeLists.txt
+++ b/lifecycle_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 set(msg_files
   "msg/State.msg"
@@ -30,6 +31,7 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
+  DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/lifecycle_msgs/msg/TransitionEvent.msg
+++ b/lifecycle_msgs/msg/TransitionEvent.msg
@@ -1,5 +1,5 @@
 # The time point at which this event occurred.
-uint64 timestamp
+builtin_interfaces/Time stamp
 
 # The id and label of this transition event.
 Transition transition

--- a/lifecycle_msgs/package.xml
+++ b/lifecycle_msgs/package.xml
@@ -16,6 +16,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Use `builtin_interfaces/Time` for the timestamp in  `lifecycle_msgs/TransitionEvent`

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #184 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, the field name has been changed to be more in line with other uses (`stamp` instead of `timestamp`).
Furthermore, the type has been changed from `uint64` to `builtin_interfaces/Time` to allow it to be more easily used by preexisting tooling.

The impact will be minimal, since the `timestamp` field is currently not being filled in `rcl_lifecycle` (ros2/rcl#1019).

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
