### PR TITLE
Add 'executor_type' and 'thread_num' to LoadNode

### DIFF
--- a/composition_interfaces/srv/LoadNode.srv
+++ b/composition_interfaces/srv/LoadNode.srv
@@ -28,6 +28,19 @@ rcl_interfaces/Parameter[] parameters
 
 # key/value arguments that are specific to a type of container process.
 rcl_interfaces/Parameter[] extra_arguments
+
+# Executor used for this node. Leave empty to share the executor
+# used for the ComponentManager. Otherwise, a new executor will
+# be used for this node. Options:
+#   + SingleThreadedExecutor
+#   + MultiThreadedExecutor
+string executor_type
+
+# Number of threads dedicated to the executor for this node. This option
+# is only valid if you choose MultiThreadedExecutor as the executor type.
+# Leave empty to use the default.
+uint8 thread_num
+
 ---
 # True if the node was successfully loaded.
 bool success


### PR DESCRIPTION
## Description

This pull request is related to ros2/rclcpp#2930 and ros2/rclcpp#3080. It adds the parameters `executor_type` and `thread_num` to `composition_interfaces/srv/LoadNode`.

### Is this user-facing behavior change?

### Did you use Generative AI?

No.

### Additional Information

Nothing.
