### PR TITLE
Actually build the new graph description messages

### DIFF
--- a/rosgraph_msgs/CMakeLists.txt
+++ b/rosgraph_msgs/CMakeLists.txt
@@ -13,14 +13,23 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
-  "msg/Clock.msg"
+  msg/Action.msg
+  msg/Clock.msg
+  msg/Graph.msg
+  msg/InterfaceType.msg
+  msg/Node.msg
+  msg/QoSProfile.msg
+  msg/Service.msg
+  msg/Topic.msg
+  msg/TypeHash.msg
 )
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces rcl_interfaces
   ADD_LINTER_TESTS
 )
 

--- a/rosgraph_msgs/README.md
+++ b/rosgraph_msgs/README.md
@@ -9,8 +9,8 @@ For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros
 
 ## Messages (.msg)
 
-* [Clock](msg/Clock.msg): Communicates the current ROS time.
 * [Action](msg/Action.msg): Describes an Action endpoint (server or client).
+* [Clock](msg/Clock.msg): Communicates the current ROS time.
 * [Graph](msg/Graph.msg): A list of Nodes, describing a running ROS graph.
 * [InterfaceType](msg/InterfaceType.msg): Describes the name and hash of an interface's type.
 * [Node](msg/Node.msg): Describes a running Node with all realized names and values.

--- a/rosgraph_msgs/README.md
+++ b/rosgraph_msgs/README.md
@@ -1,12 +1,24 @@
 # rosgraph_msgs
-This is a package containing message definitions relating to the ROS Computation Graph. These are generally considered to be low-level messages that end users do not interact with.
+
+This is a package containing message definitions relating to the ROS Computation Graph.
+These are generally considered to be low-level messages that end users do not interact with.
 
 For more information about ROS 2 clock, see [design.ros2.org](https://design.ros2.org/articles/clock_and_time.html).
 
 For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html).
 
 ## Messages (.msg)
+
 * [Clock](msg/Clock.msg): Communicates the current ROS time.
+* [Action](msg/Action.msg): Describes an Action endpoint (server or client).
+* [Graph](msg/Graph.msg): A list of Nodes, describing a running ROS graph.
+* [InterfaceType](msg/InterfaceType.msg): Describes the name and hash of an interface's type.
+* [Node](msg/Node.msg): Describes a running Node with all realized names and values.
+* [QoSProfile](msg/QoSProfile.msg): Represents the actual Quality of Service profile of an interface endpoint.
+* [Service](msg/Service.msg): Represents a Service endpoint (server or client).
+* [Topic](msg/Topic.msg): Represents a Topic endpoint (publisher or subscription).
+* [TypeHash](msg/TypeHash.msg): Encodes the hash of a ROS interface type, uniquely identifying it when definitions may change over time.
 
 ## Quality Declaration
+
 This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
## Description

Followup to #188 - we merged the message definitions without adding them to CMake to be built and installed.

This change builds the messages, and mentions them in the README.md

### Is this user-facing behavior change?

Yes - adds new messages to the resulting package

### Did you use Generative AI?

no

