### PR TITLE
fix(test_msgs): add missing find_package for ament_cmake_mypy

### DIFF
--- a/test_msgs/CMakeLists.txt
+++ b/test_msgs/CMakeLists.txt
@@ -50,6 +50,7 @@ if(BUILD_TESTING)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_mypy)
   ament_lint_auto_find_test_dependencies()
 
+  find_package(ament_cmake_mypy REQUIRED)
   ament_mypy(
     AMENT_STRICT
   )


### PR DESCRIPTION
## Description

PR https://github.com/ros2/rcl_interfaces/pull/187 added `ament_mypy(AMENT_STRICT)` to `test_msgs/CMakeLists.txt` but excluded `ament_cmake_mypy` from `ament_lint_auto_find_test_dependencies()`. Since that macro uses `find_package(... QUIET)`, the package is silently skipped when not installed, and the direct `ament_mypy()` call fails with `"Unknown CMake command"` at configure time.

This is reproducible when `rosdep install` is invoked without `--dependency-types test` (e.g. `ros-tooling/action-ros-ci@v0.4`), because `ament_cmake_mypy` is listed only as `<test_depend>` in `package.xml`.

Fixes #196

### Is this user-facing behavior change?

### Did you use Generative AI?

### Additional Information

Failing downstream CI: https://github.com/ros2/rust/actions/runs/25359425450/job/74789327509
Downstream workaround: https://github.com/ros2-rust/ros2_rust/pull/635

Error excerpt:

```
--- output: test_msgs

...

-- Found ament_lint_auto: 0.20.2
CMake Error at CMakeLists.txt:53 (ament_mypy):
  Unknown CMake command "ament_mypy".
-- Configuring incomplete, errors occurred!
---
--- stderr: test_msgs
CMake Error at CMakeLists.txt:53 (ament_mypy):
  Unknown CMake command "ament_mypy".
---
Failed   <<< test_msgs [4.43s, exited with code 1]
Aborted  <<< rcl_interfaces [4.58s]
Aborted  <<< example_interfaces [4.69s]
Summary: 11 packages finished [40.0s]
  1 package failed: test_msgs
  2 packages aborted: example_interfaces rcl_interfaces
  1 package had stderr output: test_msgs
  2 packages not processed
```