### PR TITLE
fix package.xml deps

### DIFF
--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -20,9 +20,11 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>test_interface_files</build_depend>
 
+  <exec_depend>action_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>python3-typing-extensions</exec_depend>
+  <exec_depend>service_msgs</exec_depend>
+  <exec_depend>unique_identifier_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/test_msgs/package.xml
+++ b/test_msgs/package.xml
@@ -20,10 +20,9 @@
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>test_interface_files</build_depend>
 
-  <exec_depend>action_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>service_msgs</exec_depend>
+  <exec_depend>python3-typing-extensions</exec_depend>
   <exec_depend>unique_identifier_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

Adds dependencies to package.xml that are required for message types that are pulled in from test_interface_files.

Not sure if this is the right place for this change - I know action_msgs and service_msgs are treated as special cases sometimes.

### Is this user-facing behavior change?

Yes, fixes microxrcedds

### Did you use Generative AI?

No

### Additional Information

I was getting issues with some symbols from unique_identifier_msgs not being found because the build would sometimes happen out of order. Explicitly adding these dependencies fixes the issue.

Dependency Chain:

  1. Fibonacci.action (from test_interface_files) → generates action interfaces
  2. Action interfaces automatically include action_msgs types (SendGoal, GetResult, etc.)
  3. action_msgs/msg/GoalInfo.msg uses unique_identifier_msgs/UUID goal_id
